### PR TITLE
Fixed invalid link

### DIFF
--- a/app/templates/donations.html
+++ b/app/templates/donations.html
@@ -24,7 +24,7 @@
   (<i>!</i>) different ways of applying firmware already,
   vendors are slowly either switching to a more standard mechanism for new
   products (<a href="https://github.com/rhboot/fwupdate">UpdateCapsule</a>,
-  <a href="www.usb.org/developers/docs/devclass_docs/DFU_1.1.pdf">DFU</a> or
+  <a href="https://www.usb.org/developers/docs/devclass_docs/DFU_1.1.pdf">DFU</a> or
   <a href="https://www.dmtf.org/standards/redfish">Redfish</a>) or building
   custom plugins for fwupd to update existing hardware.
 </p>


### PR DESCRIPTION
Without the http/https the usb.org link was having https://fwupd.org prepended to it creating an invalid link.