### PR TITLE
Support uploading MSZIP files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ IMPORTANT: This needs to be hosted over SSL, i.e. with a `https://` prefix.
 
     yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     yum install \
+      bsdtar \
       cabextract \
       git \
       httpd \
@@ -99,7 +100,6 @@ Then add something like this to `lvfs-website/app/lvfs.cfg`:
     PORT = 80
     DOWNLOAD_DIR = '/home/lvfs/downloads'
     KEYRING_DIR = '/home/lvfs/.gnupg'
-    CABEXTRACT_CMD = '/usr/bin/cabextract'
     CDN_URI = 'https://s3.amazonaws.com/lvfsbucket'
     CDN_BUCKET = 'lvfsbucket'
     DATABASE_HOST = 'localhost'

--- a/app/flaskapp.cfg
+++ b/app/flaskapp.cfg
@@ -8,7 +8,6 @@ IP = '127.0.0.1'
 PORT = 8080
 DOWNLOAD_DIR = '/home/hughsie/Code/lvfs-website/downloads/'
 KEYRING_DIR = 'gnupg'
-CABEXTRACT_CMD = '/usr/bin/cabextract'
 CDN_URI = None
 CDN_BUCKET = None
 DATABASE_HOST = 'localhost'

--- a/app/foreign_archive.py
+++ b/app/foreign_archive.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import cabarchive
+
+def _listdir_recurse(basedir):
+    """ Return all files and folders """
+    files = []
+    for res in os.listdir(basedir):
+        fn = os.path.join(basedir, res)
+        if not os.path.isfile(fn):
+            children = _listdir_recurse(fn)
+            files.extend(children)
+            continue
+        files.append(fn)
+    return files
+
+def _build_cab(filename, buf, tmpdir=None):
+
+    # write to temp file
+    src = tempfile.NamedTemporaryFile(mode='wb',
+                                      prefix='foreignarchive_',
+                                      suffix=".cab",
+                                      dir=tmpdir,
+                                      delete=True)
+    src.write(buf)
+    src.flush()
+
+    # decompress to a temp directory
+    dest_fn = tempfile.mkdtemp(prefix='foreignarchive_', dir=tmpdir)
+
+    # work out what binary to use
+    split = filename.rsplit('.', 1)
+    if len(split) < 2:
+        raise cabarchive.NotSupportedError('Filename not valid')
+    if split[1] == 'zip':
+        argv = ['/usr/bin/bsdtar', '--directory', dest_fn, '-xvf', src.name]
+    elif split[1] == 'cab':
+        argv = ['/usr/bin/cabextract', '--quiet', '--directory', dest_fn, src.name]
+    else:
+        raise cabarchive.NotSupportedError('Filename had no supported extension')
+
+    # extract
+    ps = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if ps.wait() != 0:
+        raise cabarchive.CorruptionError('Failed to extract: %s' % ps.stderr.read())
+
+    # add all the fake CFFILE objects
+    arc = cabarchive.CabArchive()
+    for fn in _listdir_recurse(dest_fn):
+        cff = cabarchive.CabFile(os.path.basename(fn.replace('\\', '/')))
+        cff.contents = open(fn, 'rb').read()
+        arc.add_file(cff)
+    shutil.rmtree(dest_fn)
+    src.close()
+    return arc


### PR DESCRIPTION
Microsoft requires .CAB file to upload to Windows Hardware Dev Center, however
after the content is signed by Microsoft, it's unavailable in .CAB format from
Hardware Dev Center. It's instead distributed using .ZIP file.

Allow LVFS to accept the ZIP file format and repack it into CAB. This will make
it easier to re-use content otherwise headed to Windows Update.

Fixes https://github.com/hughsie/lvfs-website/issues/20