### PR TITLE
Add a plugin that allows copying .cat and .inf files from the source …

### DIFF
--- a/app/pluginloader.py
+++ b/app/pluginloader.py
@@ -147,6 +147,17 @@ class Pluginloader(object):
                     _event_log('Plugin %s failed for ArchiveSign(): %s' % (plugin.id, str(e)))
 
     # an archive is being built
+    def archive_copy(self, arc, firmware_cff):
+        if not self.loaded:
+            self.load_plugins()
+        for plugin in self._plugins:
+            if hasattr(plugin, 'archive_copy'):
+                try:
+                    plugin.archive_copy(arc, firmware_cff)
+                except PluginError as e:
+                    _event_log('Plugin %s failed for archive_copy(): %s' % (plugin.id, str(e)))
+
+    # an archive is being built
     def archive_finalize(self, arc, metadata=None):
         if not self.loaded:
             self.load_plugins()

--- a/app/uploadedfile.py
+++ b/app/uploadedfile.py
@@ -298,6 +298,12 @@ class UploadedFile(object):
         # load metainfo files
         self._load_metainfos()
 
+        # allow plugins to copy any extra files from the source archive
+        if self._ploader:
+            for cffolder in self._src_arc.get_folders():
+                for cffile in cffolder.get_files():
+                    self._ploader.archive_copy(self._repacked_cfarchive, cffile)
+
     def get_components(self):
         """ gets all detected AppStream components """
         return self._components

--- a/plugins/wu-copy/__init__.py
+++ b/plugins/wu-copy/__init__.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+
+from app.pluginloader import PluginBase, PluginSettingBool
+from app import db, ploader
+from app.util import _get_basename_safe, _archive_add
+
+class Plugin(PluginBase):
+    def __init__(self):
+        PluginBase.__init__(self)
+
+    def name(self):
+        return 'Windows Update'
+
+    def summary(self):
+        return 'Copy files generated using Windows Update.'
+
+    def settings(self):
+        s = []
+        s.append(PluginSettingBool('wu_copy_inf', 'Include .inf files', True))
+        s.append(PluginSettingBool('wu_copy_cat', 'Include .cat files', True))
+        return s
+
+    def archive_copy(self, arc, firmware_cff):
+
+        settings = db.settings.get_filtered('wu_copy_')
+        fn = _get_basename_safe(firmware_cff.get_name())
+        if fn.endswith('.inf') and settings['inf'] == 'enabled':
+            _archive_add(arc, fn, firmware_cff.get_bytes().get_data())
+        if fn.endswith('.cat') and settings['cat'] == 'enabled':
+            _archive_add(arc, fn, firmware_cff.get_bytes().get_data())


### PR DESCRIPTION
…archive

This allows a vendor to use the 'output' of Windows Update as the 'input' to
the LVFS and have one archive that can be used on either OS.

Fixes https://github.com/hughsie/lvfs-website/issues/40