### PR TITLE
Don't store the report data as a JSON blob

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -35,12 +35,31 @@ class Database(object):
     def modify_db(self):
 
         # get current schema version
-        from .models import Setting
+        from .models import Setting, Report, _get_flat_dict_from_json, ReportAttribute
         setting = self.session.query(Setting).filter(Setting.key == 'db_schema_version').first()
         if not setting:
             print('Setting initial schema version')
             setting = Setting('db_schema_version', str(0))
             self.session.add(setting)
+
+        if int(setting.value) == 19:
+            print('Creating ReportAttribute table')
+            self.Base.metadata.tables['report_attributes'].create(bind=self.engine, checkfirst=True)
+            for r in self.session.query(Report).all():
+                data = _get_flat_dict_from_json(r.unsed_json)
+                del data['Created']
+                del data['Modified']
+                del data['BootTime']
+                del data['UpdateState']
+                del data['Checksum']
+                if 'DeviceId' in data:
+                    del data['DeviceId']
+                for key in data:
+                    self.session.add(ReportAttribute(r.report_id, key, data[key]))
+            setting.value = 20
+            print('Committing transaction')
+            self.session.commit()
+            return
 
         print('No schema changes required')
 

--- a/app/models.py
+++ b/app/models.py
@@ -517,40 +517,75 @@ def _get_flat_dict_from_json(txt):
             for key2 in items2:
                 data[key2] = items2[key2]
             continue
-        data[key] = items[key]
+        data[key] = unicode(items[key]).encode('ascii', 'ignore')
     return data
+
+class ReportAttribute(db.Base):
+    __tablename__ = 'report_attributes'
+    report_attribute_id = Column(Integer, primary_key=True, nullable=False, unique=True)
+    report_id = Column(Integer, ForeignKey('reports.report_id'), nullable=False)
+    key = Column(Text)
+    value = Column(Text)
+
+    # link back to parent
+    report = relationship("Report", back_populates="attributes")
+
+    def __init__(self, report_id=0, key=None, value=None):
+        """ Constructor for object """
+        self.report_id = report_id
+        self.key = key
+        self.value = value
+
+    def __repr__(self):
+        return "ReportAttribute object %s=%s" % (self.key, self.value)
 
 class Report(db.Base):
 
     # sqlalchemy metadata
     __tablename__ = 'reports'
-    id = Column(Integer, primary_key=True, nullable=False, unique=True)
+    report_id = Column(Integer, primary_key=True, nullable=False, unique=True)
     timestamp = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
     state = Column(Integer, default=0)
-    json = Column(Text)
+    unsed_json = Column('json', Text)
     machine_id = Column(String(64), nullable=False)
     firmware_id = Column(Integer, ForeignKey('firmware.firmware_id'), nullable=False)
-    checksum = Column(String(64), nullable=False)
+    checksum = Column(String(64), nullable=False) #fixme remove?
     issue_id = Column(Integer, default=0)
 
     # link using foreign keys
     fw = relationship('Firmware', foreign_keys=[firmware_id])
+    attributes = relationship("ReportAttribute", back_populates="report")
 
-    def __init__(self, firmware_id, machine_id=None, state=0, checksum=None, json_raw=None, issue_id=0):
+    def __init__(self, firmware_id, machine_id=None, state=0, checksum=None, issue_id=0):
         """ Constructor for object """
         self.timestamp = None
         self.state = state
-        self.json = json_raw
         self.machine_id = machine_id
         self.firmware_id = firmware_id
         self.issue_id = issue_id
         self.checksum = checksum
 
     def to_flat_dict(self):
-        return _get_flat_dict_from_json(self.json)
+        data = {}
+        if self.state:
+            data['UpdateState'] = self.state
+        if self.machine_id:
+            data['MachineId'] = self.machine_id
+        if self.firmware_id:
+            data['FirmwareId'] = self.firmware_id
+        for attr in self.attributes:
+            data[attr.key] = attr.value
+        return data
+
+    def to_kvs(self):
+        flat_dict = self.to_flat_dict()
+        kv_array = []
+        for key in flat_dict:
+            kv_array.append('%s=%s' % (key, flat_dict[key]))
+        return ', '.join(kv_array)
 
     def __repr__(self):
-        return "Report object %s" % self.id
+        return "Report object %s" % self.report_id
 
 class Setting(db.Base):
 

--- a/app/templates/analytics-reports.html
+++ b/app/templates/analytics-reports.html
@@ -31,16 +31,15 @@
 <table class="table">
   <tr class="row">
     <th class="col-sm-2">Timestamp</th>
-    <th class="col-sm-2">State</th>
+    <th class="col-sm-1">State</th>
     <th class="col-sm-2">Machine</th>
-    <th class="col-sm-2">Checksum</th>
-    <th class="col-sm-2">Firmware</th>
+    <th class="col-sm-5">Firmware</th>
     <th class="col-sm-2">&nbsp;</th>
   </tr>
 {% for r in reports %}
   <tr class="row">
     <td class="col-sm-2">{{r.timestamp}}</td>
-    <td class="col-sm-2">
+    <td class="col-sm-1">
 {% if r.state == 0 %}
       <p class="text-warning">Unknown</p>
 {% elif r.state == 1 %}
@@ -58,17 +57,16 @@
 {% endif %}
     </td>
     <td class="col-sm-2"><code>{{r.machine_id|truncate(13, False, '…')}}</code></td>
-    <td class="col-sm-2"><code>{{r.checksum|truncate(13, False, '…')}}</code></td>
-    <td class="col-sm-2">
+    <td class="col-sm-5">
 {% if r.firmware_id %}
-      <a href="/lvfs/firmware/{{r.firmware_id}}"><code>{{r.fw.checksum_upload|truncate(13, False, '…')}}</code></a></td>
+      <a href="/lvfs/firmware/{{r.firmware_id}}"><code>{{r.fw.filename[41:]}}</code></a></td>
 {% else %}
       <p class="text-danger">Not known!</p>
 {% endif %}
     </td>
     <td class="col-sm-2 text-right">
-      <a class="btn btn-danger" href="/lvfs/report/{{r.id}}/delete">Delete</a>
-      <a class="btn btn-info" href="/lvfs/report/{{r.id}}">Details</a>
+      <a class="btn btn-danger" href="/lvfs/report/{{r.report_id}}/delete">Delete</a>
+      <a class="btn btn-info" href="/lvfs/report/{{r.report_id}}">Details</a>
     </td>
   </tr>
 {% endfor %}

--- a/app/templates/firmware-analytics-reports.html
+++ b/app/templates/firmware-analytics-reports.html
@@ -67,7 +67,7 @@
     <td class="col-sm-8"><code>{{r.json}}</code></td>
     <td class="col-sm-1 text-right">
 {% if g.user.check_capability('admin') %}
-      <a class="btn btn-danger" href="/lvfs/report/{{r.id}}/delete">Delete</a>
+      <a class="btn btn-danger" href="/lvfs/report/{{r.report_id}}/delete">Delete</a>
 {% endif %}
     </td>
   </tr>

--- a/app/templates/issue-reports.html
+++ b/app/templates/issue-reports.html
@@ -29,7 +29,7 @@
 {% for r in reports %}
   <tr class="row">
     <td class="col-sm-2">{{r.timestamp}}</td>
-    <td class="col-sm-10"><code>{{r.json}}</code></td>
+    <td class="col-sm-10"><code>{{r.to_kvs()}}</code></td>
   </tr>
 {% endfor %}
 {% for r in reports_hidden %}

--- a/lvfs_test.py
+++ b/lvfs_test.py
@@ -594,7 +594,7 @@ class LvfsTestCase(unittest.TestCase):
 
         # check the saved report
         rv = self.app.get('/lvfs/report/1')
-        assert b'"UpdateState": 2' in rv.data, rv.data
+        assert b'UpdateState=2' in rv.data, rv.data
 
         # check the report appeared on the telemetry page
         rv = self.app.get('/lvfs/telemetry')


### PR DESCRIPTION
I did originally think that the JSON would just be useful for read-only review,
until we started "fixing up" reports as conditions were added.

Parsing a large blob of JSON blobs when we have thousands of reports just isn't
going to scale. Split out a new table that we can query directly.

To migrate, do:

    ALTER TABLE reports CHANGE id report_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY;

Then do:

    FLASK_APP=app/__init__.py flask-2 modifydb