### PR TITLE
Allow vendors to hide the direct download link in the search results

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -505,6 +505,7 @@ class Firmware(db.Base):
     target = Column(String(255), nullable=False)
     checksum_signed = Column(String(40), nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
+    inhibit_download = Column(Boolean, default=False)
 
     # include all Component objects
     mds = relationship("Component", back_populates="fw", lazy='joined')

--- a/app/templates/device.html
+++ b/app/templates/device.html
@@ -50,7 +50,18 @@
   </tr>
   <tr class="row">
     <th class="col-sm-2">Filename</th>
-    <td class="col-sm-10"><a href="/downloads/{{fw.filename}}">{{fw.filename}}</a></td>
+    <td class="col-sm-10">
+{% if fw.inhibit_download %}
+      <p class="text-muted">
+        The OEM that uploaded this firmware has chosen to disable downloads of
+        the firmware when using a web browser.
+        End users should use a client such as fwupdmgr to download and deploy
+        the firmware.
+      </p>
+{% else %}
+      <a href="/downloads/{{fw.filename}}">{{fw.filename}}</a>
+{% endif %}
+    </td>
   </tr>
   <tr class="row">
     <th class="col-sm-2">Description</th>

--- a/app/templates/firmware-details.html
+++ b/app/templates/firmware-details.html
@@ -60,7 +60,12 @@
 <table class="table">
   <tr class="row">
     <th class="col-sm-4 align-middle">Filename</th>
-    <td class="col-sm-6 align-middle"><a href="/downloads/{{fw.filename}}">{{orig_filename}}</a></td>
+    <td class="col-sm-6 align-middle">
+      <a href="/downloads/{{fw.filename}}">{{orig_filename}}</a>
+{% if fw.inhibit_download %}
+      <span class="text-muted">(direct link for download not available for end-users)</span>
+{% endif %}
+    </td>
     <td class="col-sm-2 text-right">
 {% if fw.target != 'stable' or g.user.is_qa %}
       <button type="button" class="btn btn-block btn-danger" data-toggle="modal" data-target="#deleteModal">Delete</button>

--- a/app/templates/metainfo.html
+++ b/app/templates/metainfo.html
@@ -80,6 +80,19 @@ An example <code>metainfo.xml</code> file looks like this:
   the firmware is published to stable channel.
 </p>
 
+<h2>Restricting direct downloads</h2>
+<p>
+  If you'd rather not have users downloading the .cab archive directly you
+  can opt to hide the direct download links in the LVFS search results.
+  To do this, add this to the metainfo file:
+</p>
+<pre>
+  &lt;!-- most OEMs do not need to do this... --&gt;
+  &lt;custom&gt;
+    &lt;value key="LVFS::InhibitDownload"/&gt;
+  &lt;/custom&gt;
+</pre>
+
 <h2>Style Guide</h2>
 
 <table class="table">

--- a/app/uploadedfile.py
+++ b/app/uploadedfile.py
@@ -97,6 +97,7 @@ class UploadedFile(object):
         self.filename_new = None
         self.fwupd_min_version = '0.8.0'    # a guess, but everyone should have this
         self.version_display = None
+        self.metadata = {}
 
         # strip out any unlisted files
         self._repacked_cfarchive = GCab.Cabinet.new()
@@ -245,6 +246,9 @@ class UploadedFile(object):
                                              'org.freedesktop.fwupd')
         if req:
             self.fwupd_min_version = req.get_version()
+
+        # get any metadata
+        self.metadata = component.get_metadata()
 
         # ensure there's always a container checksum
         release = component.get_release_default()

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -145,6 +145,10 @@ def upload():
     if ufile.version_display:
         fw.version_display = ufile.version_display
 
+    # this allows an OEM to hide the direct download link on the LVFS
+    if 'LVFS::InhibitDownload' in ufile.metadata:
+        fw.inhibit_download = True
+
     # create child metadata object for the component
     for component in ufile.get_components():
         md = Component()

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y install \
 	python-sqlalchemy \
 	python-flask \
 	python-flask-wft
-RUN yum -y install https://kojipkgs.fedoraproject.org//packages/libappstream-glib/0.7.6/1.fc27/x86_64/libappstream-glib-0.7.6-1.fc27.x86_64.rpm
+RUN yum -y install https://kojipkgs.fedoraproject.org//packages/libappstream-glib/0.7.7/1.fc27/x86_64/libappstream-glib-0.7.7-1.fc27.x86_64.rpm
 RUN yum -y install https://kojipkgs.fedoraproject.org//packages/gcab/1.1/1.fc27/x86_64/libgcab1-1.1-1.fc27.x86_64.rpm
 RUN yum -y install https://kojipkgs.fedoraproject.org//packages/python-flask/0.11.1/6.fc27/noarch/python2-flask-0.11.1-6.fc27.noarch.rpm
 RUN yum -y install https://people.freedesktop.org/~hughsient/temp/python2-flask_oauthlib-0.3.0-1.fc27.noarch.rpm

--- a/uploadedfile_test.py
+++ b/uploadedfile_test.py
@@ -41,6 +41,10 @@ def _get_valid_metainfo(release_description='This stable release fixes bugs'):
       <description><p>%s</p></description>
     </release>
   </releases>
+  <custom>
+    <value key="foo">bar</value>
+    <value key="LVFS::InhibitDownload"/>
+  </custom>
 </component>
 """ % release_description
 
@@ -137,6 +141,18 @@ class TestStringMethods(unittest.TestCase):
         arc2 = ufile.get_repacked_cabinet()
         self.assertIsNotNone(_archive_get_files_from_glob(arc2, 'firmware.bin'))
         self.assertIsNotNone(_archive_get_files_from_glob(arc2, 'firmware.metainfo.xml'))
+
+    # valid metadata
+    def test_metadata(self):
+        arc = GCab.Cabinet.new()
+        _archive_add(arc, 'firmware.bin', _get_valid_firmware())
+        _archive_add(arc, 'firmware.metainfo.xml', _get_valid_metainfo())
+        ufile = UploadedFile()
+        ufile.parse('foo.cab', _archive_to_contents(arc))
+        self.assertTrue('foo' in ufile.metadata)
+        self.assertTrue('LVFS::InhibitDownload' in ufile.metadata)
+        self.assertTrue(ufile.metadata['foo'] == 'bar')
+        self.assertFalse('NotGoingToExist' in ufile.metadata)
 
     # update description references another file
     def test_release_mentions_file(self):


### PR DESCRIPTION
For arguable reasons, some vendors want to hide the direct download links for
firmware on the LVFS pages. This means the firmware files are only available to
download by programs that parse the XML metadata, for instance gnome-software
and fwupdmgr.

To migrate, do:

    ALTER TABLE firmware ADD inhibit_download TINYINT DEFAULT 0;

To use this in firmware files, include a section in the metainfo.xml as follows:

    <custom>
      <value key=LVFS::InhibitDownload/>
    </custom>