### PR TITLE
index username,password in users table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,8 +12,9 @@ import re
 
 from gi.repository import AppStreamGlib
 
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, Index
 from sqlalchemy.orm import relationship
+from sqlalchemy.dialects import mysql
 
 from app import db
 
@@ -28,10 +29,13 @@ class User(db.Model):
 
     # database
     __tablename__ = 'users'
-    user_id = Column(Integer, primary_key=True, unique=True, nullable=False)
-    username = Column(Text, nullable=False)
+    __table_args__ = (
+        Index("idx_username_password", "username", "password"),
+        )
+    user_id = Column(Integer, primary_key=True)
+    username = Column(String(80), nullable=False)
     username_old = Column(Text, default=None)
-    password = Column(Text, default=None)
+    password = Column(mysql.BINARY(40), default=None)
     display_name = Column(Text, default=None)
     vendor_id = Column(Integer, ForeignKey('vendors.vendor_id'), nullable=False)
     auth_type = Column(Text, default='disabled')

--- a/migrations/versions/5e87dae99eab_user_table_index.py
+++ b/migrations/versions/5e87dae99eab_user_table_index.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 5e87dae99eab
+Revises: f49b79b3ffdd
+Create Date: 2018-04-02 11:07:13.698622
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5e87dae99eab'
+down_revision = 'f49b79b3ffdd'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.drop_index('user_id', table_name='users')
+    op.alter_column('users', 'username', existing_type=sa.Text, existing_nullable=False,
+        type_=sa.String(80))
+    op.alter_column('users', 'password', existing_type=sa.Text, existing_nullable=True,
+        type_=mysql.BINARY(40))
+    op.create_index('idx_username_password', 'users', ['username', 'password'])
+
+
+def downgrade():
+    op.create_index('user_id', 'users', ['user_id'], unique=True)
+    op.drop_index('idx_username_password', 'users')
+    op.alter_column('users', 'username', existing_type=sa.String(80), existing_nullable=False,
+        type_=sa.Text)
+    op.alter_column('users', 'password', existing_type=mysql.BINARY(40), existing_nullable=True,
+        type_=sa.Text)


### PR DESCRIPTION
A simple login with username and password resulted in the slow query log
entry at the end of this commit. There was no index the query could use.

Fixing this requires a number of aspects:
username and password being Text types have an large size (64k+) and
mysql indexs are of a bounded length. As such we change ther username back
to a 80 character string. The password field is currently a hash and is
always 40 characters long.

To lookup in a users table the username, and optionally the password as
well, the username,password composite index is created.

While we are changing the username table, we drop the unique index on
the primary key, user_id. Primary keys are always unique so there is no
use for this index.

After the change the query no-longer shows in the slow query log however
the query plan shows the use of the created index:

MariaDB [lvfs]> explain SELECT users.user_id AS users_user_id, users.username AS users_username, users.username_old AS users_username_old, users.password AS users_password, users.display_name AS users_display_name, users.vendor_id AS users_vendor_id, users.auth_type AS users_auth_type, users.is_qa AS users_is_qa, users.is_analyst AS users_is_analyst, users.is_vendor_manager AS users_is_vendor_manager, users.is_admin AS users_is_admin FROM users WHERE users.username = 'admin' AND users.password = '7e66dc7dd6f59a5a6ffd437bffad5bb8c9127a86'\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: users
         type: ref
possible_keys: idx_username_password
          key: idx_username_password
      key_len: 123
          ref: const,const
         rows: 1
        Extra: Using index condition

Slow query log entry before this change with the explain information that a mariadb server will show:

         Query_time: 0.000291  Lock_time: 0.000118  Rows_sent: 0  Rows_examined: 2
         Rows_affected: 0
         Full_scan: Yes  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No
         Filesort: No  Filesort_on_disk: No  Merge_passes: 0  Priority_queue: No

         explain: id   select_type     table   type    possible_keys   key     key_len ref     rows    r_rows  filtered        r_filtered      Extra
         explain: 1    SIMPLE  users   ALL     NULL    NULL    NULL    NULL    2       2.00    100.00  0.00    Using where

SET timestamp=1522583968;
SELECT users.user_id AS users_user_id, users.username AS users_username, users.username_old AS users_username_old, users.password AS users_password, users.display_name AS users_display_name, users.vendor_id AS users_vendor_id, users.auth_type AS users_auth_type, users.is_qa AS users_is_qa, users.is_analyst AS users_is_analyst, users.is_vendor_manager AS users_is_vendor_manager, users.is_admin AS users_is_admin
FROM users
WHERE users.username = 'admin' AND users.password = '7e66dc7dd6f59a5a6ffd437bffad5bb8c9127a86'
 LIMIT 1;