### PR TITLE
Only show the legal agreement once rather than on every upload

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -91,3 +91,4 @@ from app import views_analytics
 from app import views_upload
 from app import views_issue
 from app import views_search
+from app import views_agreement

--- a/app/models.py
+++ b/app/models.py
@@ -25,6 +25,17 @@ class UserCapability(object):
     Analyst = 'analyst'
     User = 'user'
 
+class Agreement(db.Model):
+
+    # database
+    __tablename__ = 'agreements'
+    __table_args__ = {'mysql_character_set': 'utf8mb4'}
+
+    agreement_id = Column(Integer, primary_key=True, unique=True, nullable=False)
+    created = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    version = Column(Integer, nullable=False)
+    text = Column(Unicode, default=None)
+
 class User(db.Model):
 
     # database
@@ -44,9 +55,11 @@ class User(db.Model):
     is_analyst = Column(Boolean, default=False)
     is_vendor_manager = Column(Boolean, default=False)
     is_admin = Column(Boolean, default=False)
+    agreement_id = Column(Integer, ForeignKey('agreements.agreement_id'))
 
     # link using foreign keys
     vendor = relationship('Vendor', foreign_keys=[vendor_id])
+    agreement = relationship('Agreement', foreign_keys=[agreement_id])
 
     def __init__(self, username, password=None, display_name=None,
                  vendor_id=None, auth_type='disabled', is_analyst=False, is_qa=False,
@@ -192,6 +205,8 @@ class Restriction(db.Model):
 
     # sqlalchemy metadata
     __tablename__ = 'restrictions'
+    __table_args__ = {'mysql_character_set': 'utf8mb4'}
+
     restriction_id = Column(Integer, primary_key=True, unique=True, nullable=False)
     vendor_id = Column(Integer, ForeignKey('vendors.vendor_id'), nullable=False)
     value = Column(Text, nullable=False)

--- a/app/templates/agreement-admin.html
+++ b/app/templates/agreement-admin.html
@@ -1,0 +1,20 @@
+{% extends "default.html" %}
+{% block title %}Legal Agreement{% endblock %}
+
+{% block content %}
+
+<h2>Legal Agreement</h2>
+<form method="post" action="/lvfs/agreement/{{agreement.agreement_id}}/modify">
+  <div class="form-group">
+    <label for="version">Version (incrementing will prompt users):</label>
+    <input type="number" class="form-control" name="version" value="{{agreement.version}}" required>
+  </div>
+  <div class="form-group">
+    <label for="text">Markup in HTML format:</label>
+    <textarea class="form-control" name="text" cols="100" rows="25">{{agreement.text}}</textarea>
+  </div>
+  <input type="submit" class="btn btn-primary" class="submit" value="Modify">
+  <a class="btn btn-danger" href="/lvfs/agreement/{{agreement.agreement_id}}/delete">Delete</a>
+</form>
+
+{% endblock %}

--- a/app/templates/agreement-list.html
+++ b/app/templates/agreement-list.html
@@ -1,0 +1,35 @@
+{% extends "default.html" %}
+{% block title %}Agreement List{% endblock %}
+
+{% block content %}
+<h1>Agreement List</h1>
+{% if agreements|length > 0 %}
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-2">Created</th>
+    <th class="col-sm-1">Version</th>
+    <th class="col-sm-7">Text</th>
+    <th class="col-sm-2">&nbsp;</th>
+  </tr>
+{% for u in agreements|sort(attribute='created',reverse=True) %}
+  <tr class="row">
+    <td class="col-sm-2">{{u.created}}</td>
+    <td class="col-sm-1">{{u.version}}</td>
+    <td class="col-sm-7">{{u.text|truncate(300, False, '…')}}</td>
+    <td class="col-sm-2">
+      <a class="btn btn-info btn-block" href="/lvfs/agreement/{{u.agreement_id}}/modify">Details</a>
+    </td>
+  </tr>
+{% endfor %}
+  <tr class="row">
+    <td class="col-sm-2"></td>
+    <td class="col-sm-1"></td>
+    <td class="col-sm-7"></td>
+    <td class="col-sm-2">
+      <a class="btn btn-info btn-block" href="/lvfs/agreement/create">Create</a>
+    </td>
+  </tr>
+</table>
+{% endif %}
+
+{% endblock %}

--- a/app/templates/agreement.html
+++ b/app/templates/agreement.html
@@ -1,0 +1,14 @@
+{% extends "default.html" %}
+{% block title %}Legal Agreement{% endblock %}
+
+{% block content %}
+
+<h2>Legal Agreement</h2>
+{{agreement.text|safe}}
+<p class="text-muted">Version {{agreement.version}}</p>
+<div class="text-center">
+  <a class="btn btn-primary btn-lg" href="/lvfs/agreement/{{agreement.agreement_id}}/accept">Agree</a>
+  <a class="btn btn-danger btn-lg" href="/lvfs/agreement/{{agreement.agreement_id}}/decline">Decline</a>
+</div>
+
+{% endblock %}

--- a/app/templates/default.html
+++ b/app/templates/default.html
@@ -86,6 +86,9 @@
 {% if g.user.check_capability('vendor-manager') %}
               <a class="dropdown-item" href="/lvfs/vendor/{{g.user.vendor_id}}/users">Vendor</a>
 {% endif %}
+{% if g.user.check_capability('admin') %}
+              <a class="dropdown-item" href="/lvfs/agreement/list">Agreements</a>
+{% endif %}
 {% if g.user.check_capability('qa') %}
               <a class="dropdown-item" href="/lvfs/eventlog">Events</a>
 {% endif %}

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -21,61 +21,10 @@
 </p>
 {% endif %}
 
-<h2>Add New Firmware</h2>
-<p>By uploading a firmware file you must agree that:</p>
-<ul>
-  <li>
-    You give the Linux Vendor Firmware System permission to redistribute the
-    files uploaded to the service, both by mirroring the content internally to
-    the current (and future) cloud providers and directly to unauthenticated end
-    users.
-  </li>
-  <li>
-    You have full permission and authority to upload the files to the LVFS and
-    are legally permitted to distribute the firmware in this way.
-  </li>
-  <li>
-    You understand the files that in the testing and stable channels are going
-    to be downloaded and installed by users, possibly automatically and without
-    user interaction.
-  </li>
-  <li>
-    You understand that users with the vendor-specific embargo token will also
-    have access to the firmware in the embargoed state.
-  </li>
-  <li>
-    You understand that the uploaded firmware archive will be unpacked, the
-    firmware binary will be signed by the LVFS GPG key and the cabinet will be
-    packed with only the files listed in the MetaInfo file.
-  </li>
-  <li>
-    You understand that functionality provided the LVFS may go away at any time
-    and without any notice, and that we provide no kind of uptime guarantee for
-    any part of the service.
-  </li>
-  <li>
-    You agree that the files uploaded have been tested on all applicable
-    hardware to the best of your ability, and no user interaction is required
-    before or after the update has completed.
-  </li>
-  <li>
-    You understand that people running this service cannot be held accountable
-    in any way if the firmware damages the end-users machine.
-  </li>
-  <li>
-    You will not allow users to share access the LVFS without permission and
-    that the user account(s) will use strong passwords.
-  </li>
-  <li>
-    You agree that all firmware uploaded will not be malicious e.g. be a virus
-    or to exploit or examine security issues.
-  </li>
-  <li>
-    You agree we will notify the LVFS administrators if the LVFS vendor account
-    is no longer required.
-  </li>
-</ul>
-
+<h2>Upload Firmware</h2>
+<p>
+  Uploading firmware is covered by <a href="/lvfs/agreement">our legal agreement</a>.
+</p>
 <form action="/lvfs/upload" method="post" enctype="multipart/form-data" class="form">
   <div class="form-group row">
     <label for="target" class="col-sm-2 col-form-label">Remote</label>

--- a/app/views_agreement.py
+++ b/app/views_agreement.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+
+from flask import request, flash, url_for, redirect, render_template, g
+from flask_login import login_required
+
+from app import app, db
+
+from .util import _error_internal, _error_permission_denied
+from .models import UserCapability, Agreement
+
+@app.route('/lvfs/agreement')
+@app.route('/lvfs/agreement/<int:agreement_id>')
+@login_required
+def agreement_show(agreement_id=None):
+    # find the right version
+    if agreement_id:
+        agreement = db.session.query(Agreement).\
+                        filter(Agreement.agreement_id == agreement_id).first()
+    else:
+        agreement = db.session.query(Agreement).\
+                        order_by(Agreement.version.desc()).first()
+    if not agreement:
+        agreement = Agreement(version=1, text=u'No agreement text found')
+        db.session.add(agreement)
+        db.session.commit()
+    return render_template('agreement.html', agreement=agreement)
+
+@app.route('/lvfs/agreement/list')
+@login_required
+def agreement_list():
+
+    # security check
+    if not g.user.check_capability(UserCapability.Admin):
+        return _error_permission_denied('Only admin is allowed to list agreements')
+
+    # find the right version
+    agreements = db.session.query(Agreement).all()
+    return render_template('agreement-list.html', agreements=agreements)
+
+@app.route('/lvfs/agreement/create')
+@login_required
+def agreement_create():
+
+    # security check
+    if not g.user.check_capability(UserCapability.Admin):
+        return _error_permission_denied('Only admin is allowed to create agreements')
+
+    # create something
+    agreement = Agreement(version=1, text=u'New agreement text')
+    db.session.add(agreement)
+    db.session.commit()
+    flash('Created agreement')
+    return redirect(url_for('.agreement_modify', agreement_id=agreement.agreement_id))
+
+@app.route('/lvfs/agreement/<int:agreement_id>/accept')
+@login_required
+def agreement_confirm(agreement_id):
+
+    # find the object for the ID
+    agreement = db.session.query(Agreement).\
+                    filter(Agreement.agreement_id == agreement_id).first()
+    if not agreement:
+        flash('No argreement ID found', 'warning')
+        return redirect(url_for('.agreement_show'))
+
+    # already agreed to a newer version
+    if g.user.agreement and g.user.agreement.version >= agreement.version:
+        flash('You already agreed to this version of the agreement', 'info')
+        return redirect(url_for('.agreement_show'))
+
+    # save this
+    g.user.agreement_id = agreement.agreement_id
+    db.session.commit()
+    flash('Recorded acceptance of the agreement')
+    return redirect(url_for('.upload'))
+
+@app.route('/lvfs/agreement/decline')
+@app.route('/lvfs/agreement/<int:agreement_id>/decline')
+@login_required
+def agreement_decline(agreement_id=None):
+    g.user.agreement_id = None
+    db.session.commit()
+    flash('Recorded decline of the agreement %i' % agreement_id)
+    return redirect(url_for('.index'))
+
+@app.route('/lvfs/agreement/<int:agreement_id>/modify', methods=['GET', 'POST'])
+@login_required
+def agreement_modify(agreement_id):
+
+    # security check
+    if not g.user.check_capability(UserCapability.Admin):
+        return _error_permission_denied('Only admin is allowed to modify agreements')
+
+    # match
+    agreement = db.session.query(Agreement).\
+                    filter(Agreement.agreement_id == agreement_id).first()
+    if not agreement:
+        return _error_internal('No agreement with that ID')
+
+    # view
+    if request.method != 'POST':
+        return render_template('agreement-admin.html', agreement=agreement)
+
+    # change
+    if 'version' in request.form:
+        agreement.version = int(request.form['version'])
+    if 'text' in request.form:
+        agreement.text = request.form['text']
+    db.session.commit()
+    flash('Modified agreement')
+    return redirect(url_for('.agreement_modify', agreement_id=agreement_id))
+
+@app.route('/lvfs/agreement/<int:agreement_id>/delete')
+@login_required
+def agreement_delete(agreement_id):
+
+    # security check
+    if not g.user.check_capability(UserCapability.Admin):
+        return _error_permission_denied('Only admin is allowed to delete agreements')
+
+    # match
+    agreement = db.session.query(Agreement).\
+                    filter(Agreement.agreement_id == agreement_id).first()
+    if not agreement:
+        return _error_internal('No agreement with that ID')
+
+    # change
+    db.session.delete(agreement)
+    db.session.commit()
+    flash('Deleted agreement')
+    return redirect(url_for('.agreement_list'))

--- a/migrations/versions/06b354728f66_add_the_legal_agreements.py
+++ b/migrations/versions/06b354728f66_add_the_legal_agreements.py
@@ -1,0 +1,33 @@
+"""
+
+Revision ID: 06b354728f66
+Revises: efcd3338922a
+Create Date: 2018-04-03 20:54:01.631909
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '06b354728f66'
+down_revision = 'efcd3338922a'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.create_table('agreements',
+    sa.Column('agreement_id', sa.Integer(), nullable=False),
+    sa.Column('created', sa.DateTime(), nullable=False),
+    sa.Column('version', sa.Integer(), nullable=False),
+    sa.Column('text', sa.Unicode(), nullable=True),
+    sa.PrimaryKeyConstraint('agreement_id'),
+    sa.UniqueConstraint('agreement_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.add_column(u'users', sa.Column('agreement_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'users', 'agreements', ['agreement_id'], ['agreement_id'])
+
+def downgrade():
+    op.drop_constraint(None, 'users', type_='foreignkey')
+    op.drop_column(u'users', 'agreement_id')
+    op.drop_table('agreements')


### PR DESCRIPTION
Also, add the ability to version the agreements and only prompt users of the
LVFS to re-accept the terms when the version number changes.

We need this for the migration to the Linux Foundation, where users will have
to agree that a different legal entity is going to be distributing thier
firmware. The LF legal team also want to polish up the current agreement.