### PR TITLE
Deprecate old usernames harder

### DIFF
--- a/app/templates/firmware-problems.html
+++ b/app/templates/firmware-problems.html
@@ -29,10 +29,6 @@
         <code>&lt;release urgency="high"&gt;</code> in the
         <a href="/metainfo"><code>.metainfo.xml</code></a> file.
       </p>
-      <p class="card-text">
-        From 1<sup>st</sup> September 2018 it will not be possible to move firmware
-        files to stable that do not have an urgency value.
-      </p>
     </td>
   </tr>
 {% endif %}
@@ -56,10 +52,6 @@
         in the <a href="/metainfo"><code>.metainfo.xml</code></a> file:<br/>
         <code>&lt;release&gt;&lt;description&gt;&lt;p&gt;Release note
         text&lt;/p&gt;&lt;/description&gt;&lt;/release&gt;</code>
-      </p>
-      <p class="card-text">
-        From 1<sup>st</sup> September 2018 it will not be possible to move firmware
-        files to stable that do not have an update description.
       </p>
     </td>
   </tr>

--- a/app/views_firmware.py
+++ b/app/views_firmware.py
@@ -192,6 +192,12 @@ def firmware_promote(firmware_id, target):
     if not fw.check_acl('@promote-' + target):
         return _error_permission_denied("No QA access to %s" % fw.firmware_id)
 
+    # vendor has to fix the problems first
+    if target in ['stable', 'testing'] and fw.problems:
+        probs = ','.join(fw.problems)
+        flash('Firmware has problems that must be fixed first: %s' % probs, 'warning')
+        return redirect(url_for('.firmware_show', firmware_id=firmware_id))
+
     # set new remote
     if target == 'embargo':
         remote = fw.vendor.remote


### PR DESCRIPTION
Provide the user with the information they need, but don't allow them to log in
with the old username.

In September we'll be be removing the old usernames completely as the GDPR
and product security make it important to map accounts to specific people.