### PR TITLE
Set a ReportURI in the embargo remote

### DIFF
--- a/app/views_metadata.py
+++ b/app/views_metadata.py
@@ -37,6 +37,7 @@ def metadata_remote(group_id):
     remote.append('Title=Embargoed for ' + group_id)
     remote.append('Keyring=gpg')
     remote.append('MetadataURI=https://fwupd.org/downloads/%s' % vendor.remote.filename)
+    remote.append('ReportURI=https://fwupd.org/lvfs/firmware/report')
     remote.append('OrderBefore=lvfs,fwupd')
     fn = group_id + '-embargo.conf'
     response = make_response('\n'.join(remote))


### PR DESCRIPTION
This allows users and QA testers to upload reports to the LVFS when the firmware
archive is downloaded from an embargoed remote.