### PR TITLE
Allow components to have a priority

### DIFF
--- a/app/metadata.py
+++ b/app/metadata.py
@@ -40,6 +40,7 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri=''):
                 component.set_metadata_license(md.metadata_license)
                 component.set_project_license(md.project_license)
                 component.set_developer_name(None, md.developer_name)
+                component.set_priority(md.priority)
                 components[md.appstream_id] = component
             else:
                 component = components[md.appstream_id]

--- a/app/models.py
+++ b/app/models.py
@@ -497,6 +497,7 @@ class Component(db.Model):
     screenshot_caption = Column(Unicode, default=None)
     inhibit_download = Column(Boolean, default=False)
     version_format = Column(String(10), default=None) # usually 'triplet' or 'quad'
+    priority = Column(Integer, default=0)
 
     # link back to parent
     fw = relationship("Firmware", back_populates="mds", lazy='joined')
@@ -534,6 +535,7 @@ class Component(db.Model):
         self.release_urgency = None
         self.screenshot_url = None
         self.screenshot_caption = None
+        self.priority = 0
 
     @property
     def version_format_with_vendor_fallback(self):

--- a/app/templates/firmware-components.html
+++ b/app/templates/firmware-components.html
@@ -12,7 +12,7 @@
     <th class="col-sm-7">Component ID</th>
     <th class="col-sm-2">&nbsp;</th>
   </tr>
-{% for md in fw.mds %}
+{% for md in fw.mds|sort(attribute='priority',reverse=True) %}
   <tr class="row">
     <td class="col-sm-3">
       {{md.name}} v{{md.version_display}}

--- a/app/templates/firmware-md-overview.html
+++ b/app/templates/firmware-md-overview.html
@@ -35,6 +35,12 @@
     <th class="col-sm-3">Installed Size</th>
     <td class="col-sm-9">{{format_size(md.release_installed_size)}}</td>
   </tr>
+{% if md.priority != 0 %}
+  <tr class="row">
+    <th class="col-sm-3">Priority</th>
+    <td class="col-sm-9">{{md.priority}}</td>
+  </tr>
+{% endif %}
 {% if md.screenshot_url %}
   <tr class="row">
     <th class="col-sm-3">Screenshot</th>

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -74,6 +74,7 @@ def _create_fw_from_uploaded_file(ufile):
         md.project_license = component.get_project_license()
         md.url_homepage = unicode(component.get_url_item(AppStreamGlib.UrlKind.HOMEPAGE))
         md.description = unicode(component.get_description())
+        md.priority = component.get_priority()
 
         # fix up the vendor
         if md.developer_name == 'LenovoLtd.':

--- a/migrations/versions/3fd6598319ec_add_component_priority.py
+++ b/migrations/versions/3fd6598319ec_add_component_priority.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 3fd6598319ec
+Revises: cf1db1cb7fce
+Create Date: 2018-10-18 19:55:22.394563
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3fd6598319ec'
+down_revision = 'cf1db1cb7fce'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('components', sa.Column('priority', sa.Integer(), nullable=True))
+
+def downgrade():
+    op.drop_column('components', 'priority')


### PR DESCRIPTION
This allows us to set the priority of a specific component to be largest, which
allows fwupd to order the results with the 'main' entity listed first.

The other way to do this is to simply add the files into the source .cab file
in a specific order, but I think that's fragile. It's better to be explicit
rather than relying on an assumption that the file order won't be changed when
the archive is repacked.