### PR TITLE
Use lxml to produce the XML remote metadata

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y install \
 	python2-pylint \
 	python-blinker \
 	python-humanize \
+	python-lxml \
 	python-requests \
 	python-sqlalchemy \
 	python-flask \


### PR DESCRIPTION
Using appstream-glib was convenient, but behind the scenes it was merging
elements like releases in each components in ways that we didn't want.

It's also using a slegdehammer to crack a nut; so lets make things simpler.

Fixes: https://github.com/hughsie/fwupd/issues/818