### PR TITLE
Add a per-firmware is_dirty boolean flag

### DIFF
--- a/app/metadata.py
+++ b/app/metadata.py
@@ -242,6 +242,10 @@ def _metadata_update_targets(remotes):
                                 fws_filtered,
                                 firmware_baseuri=settings['firmware_baseuri'])
 
+        # all firmwares are contained in the correct metadata now
+        for fw in fws_filtered:
+            fw.is_dirty = False
+
 def _hashfile(afile, hasher, blocksize=65536):
     buf = afile.read(blocksize)
     while len(buf) > 0:

--- a/app/models.py
+++ b/app/models.py
@@ -744,6 +744,7 @@ class Firmware(db.Model):
     checksum_signed = Column(String(40), nullable=False)
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
     signed_timestamp = Column(DateTime, default=None)
+    is_dirty = Column(Boolean, default=False)   # waiting to be included in metadata
 
     # include all Component objects
     mds = relationship("Component",

--- a/app/templates/firmware-details.html
+++ b/app/templates/firmware-details.html
@@ -27,9 +27,10 @@
   <tr class="row">
     <th class="col-sm-3 align-middle">Current Target</th>
     <td class="col-sm-7 align-middle">
-{% if fw.remote.is_signed and fw.remote.is_dirty %}
+{% if fw.remote.is_signed and fw.is_dirty %}
       <div class="alert alert-warning" role="alert">
-        The <code>{{fw.remote.name}}</code> metadata will be signed in {{format_timedelta_approx(fw.remote.scheduled_signing)}}.
+        The <code>{{fw.remote.name}}</code> metadata will be regenerated to
+        include this firmware in {{format_timedelta_approx(fw.remote.scheduled_signing)}}.
       </div>
 {% else %}
       <code>{{fw.remote.name}}</code>

--- a/app/views_firmware.py
+++ b/app/views_firmware.py
@@ -109,6 +109,7 @@ def _firmware_delete(fw):
         shutil.move(path, path_new)
 
     # generate next cron run
+    fw.is_dirty = True
     fw.remote.is_dirty = True
 
     # mark as invalid
@@ -214,6 +215,9 @@ def firmware_promote(firmware_id, target):
     # invalidate both the remote it came from and the one it's going to
     remote.is_dirty = True
     fw.remote.is_dirty = True
+
+    # invalidate the firmware as we're waiting for the metadata generation
+    fw.is_dirty = True
 
     # also dirty any ODM remote if uploading on behalf of an OEM
     if target == 'embargo' and fw.vendor != fw.user.vendor:
@@ -370,6 +374,7 @@ def firmware_affiliation_change(firmware_id):
         fw.vendor.remote.is_dirty = True
         fw.user.vendor.remote.is_dirty = True
         old_vendor.remote.is_dirty = True
+        fw.is_dirty = True
         fw.remote_id = fw.vendor.remote.remote_id
         fw.events.append(FirmwareEvent(fw.remote_id, g.user.user_id))
         db.session.commit()

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -318,6 +318,7 @@ def upload():
     fw.addr = _get_client_address()
     fw.remote_id = remote.remote_id
     fw.checksum_signed = hashlib.sha1(cab_data).hexdigest()
+    fw.is_dirty = True
 
     # add to database
     fw.events.append(FirmwareEvent(remote.remote_id, g.user.user_id))

--- a/migrations/versions/688568bacd0a_add_firmware_is_dirty.py
+++ b/migrations/versions/688568bacd0a_add_firmware_is_dirty.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 688568bacd0a
+Revises: b1851318108b
+Create Date: 2018-11-05 10:11:08.713672
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '688568bacd0a'
+down_revision = 'b1851318108b'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('firmware', sa.Column('is_dirty', sa.Boolean(), nullable=True))
+
+def downgrade():
+    op.drop_column('firmware', 'is_dirty')


### PR DESCRIPTION
At the moment moving a firmware from testing to stable shows a message

    'The stable metadata will be signed in 16 minutes'

This tells the vendor that the firmware will be soon included in the metadata.

This *also* shows on any firmware currently in stable, which means vendors are
not sure if older firmwares are actually included at that moment. Now there are
lots of different vendors using the LVFS every day, it means it's frequently
unclear what firmware is actually in the metadata at the present time.

To fix this, include a per-firmware flag that is supposed to represent 'is this
firmware pending for the requested metadata for the selected target'.

When the firmware changes remote it is 'dirtied' and once the metadata has been
successfully regenerated and signed it is marked as clean. This means we can
show a more accurate message in the per-firmware details panel, and also not
show the message for unrelated firmware that happens to already be in the same
remote.