### PR TITLE
Make the action more obvious when managing vendor users

### DIFF
--- a/app/templates/vendor-users.html
+++ b/app/templates/vendor-users.html
@@ -15,9 +15,7 @@
   </tr>
 {% for u in v.users %}
   <tr class="row">
-    <td class="col-sm-3">
-      <a href="/lvfs/user/{{u.user_id}}/admin"><code>{{u.username}}</code></a>
-    </td>
+    <td class="col-sm-3"><code>{{u.username}}</code></td>
     <td class="col-sm-2">{{u.display_name}}</td>
     <td class="col-sm-1">{{u.fws|length}}</td>
     <td class="col-sm-2">{{u.atime}}</td>
@@ -35,8 +33,8 @@
     </td>
     <td class="col-sm-2">
 {% if u.auth_type and u.user_id != g.user.user_id %}
-      <a class="btn btn-block btn-danger"
-         href="/lvfs/vendor/{{v.vendor_id}}/user/{{u.user_id}}/disable">Disable</a>
+      <a class="btn btn-block btn-info"
+         href="/lvfs/user/{{u.user_id}}/admin">Details</a>
 {% endif %}
     </td>
   </tr>

--- a/app/views_vendor.py
+++ b/app/views_vendor.py
@@ -357,31 +357,6 @@ def vendor_upload(vendor_id):
 
     return redirect(url_for('.vendor_details', vendor_id=vendor_id), 302)
 
-
-@app.route('/lvfs/vendor/<int:vendor_id>/user/<int:user_id>/disable')
-@login_required
-def vendor_user_disable(vendor_id, user_id):
-
-    # check exists
-    vendor = db.session.query(Vendor).filter(Vendor.vendor_id == vendor_id).first()
-    if not vendor:
-        flash('Failed to delete user: No vendor with that vendor ID', 'warning')
-        return redirect(url_for('.vendor_users', vendor_id=vendor_id))
-    user = db.session.query(User).filter(User.user_id == user_id).first()
-    if not user:
-        flash('Failed to delete user: No user with that user ID', 'warning')
-        return redirect(url_for('.vendor_users', vendor_id=vendor_id))
-
-    # security check
-    if not vendor.check_acl('@manage-users'):
-        return _error_permission_denied('Unable to delete user as non-admin')
-
-    # erase password and set as 'disabled'
-    user.password = None
-    user.auth_type = 'disabled'
-    db.session.commit()
-    return redirect(url_for('.vendor_users', vendor_id=vendor_id))
-
 def _verify_username_vendor_glob(username, username_glob):
     for tmp in username_glob.split(','):
         if fnmatch.fnmatch(username, tmp):


### PR DESCRIPTION
On the LVFS we usually put the 'action widget' as a button on the right hand
side of a table. In the per-vendor users view the common action was actually
going to the details, which meant you had to know you could click on the email
address. The uncommon action was a big red scary 'Disable' button that made it
look even more like this was the only way to interact with the table row.

Use a less scary 'Details' button like the rest of the LVFS, and remove the
one-click-disable misfeature.