### PR TITLE
Allow vendors to disallow firmware downloads from specific countries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -339,6 +339,7 @@ class Vendor(db.Model):
     username_glob = Column(Text, default=None)
     version_format = Column(String(10), default=None) # usually 'triplet' or 'quad'
     url = Column(Text, default=None)
+    banned_country_codes = Column(Text, default=None) # ISO 3166, delimeter ','
 
     # magically get the users in this vendor group
     users = relationship("User",
@@ -1111,6 +1112,7 @@ class Firmware(db.Model):
     user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
     signed_timestamp = Column(DateTime, default=None)
     is_dirty = Column(Boolean, default=False)   # waiting to be included in metadata
+    _banned_country_codes = Column('banned_country_codes', Text, default=None) # ISO 3166, delimeter ','
 
     # include all Component objects
     mds = relationship("Component",
@@ -1147,6 +1149,12 @@ class Firmware(db.Model):
     @property
     def is_deleted(self):
         return self.remote.is_deleted
+
+    @property
+    def banned_country_codes(self):
+        if self._banned_country_codes:
+            return self._banned_country_codes
+        return self.vendor.banned_country_codes
 
     @property
     def inhibit_download(self):

--- a/app/templates/docs-vendors.html
+++ b/app/templates/docs-vendors.html
@@ -65,4 +65,19 @@
   </div>
 </div>
 
+<div class="card mb-3">
+  <h3 class="card-header list-group-item-info">Can I restrict downloads from embargoed and sanctioned countries?</h3>
+  <div class="card-body">
+    <p class="card-text">
+      The LVFS administrator can configure the policy for all firmware owned by
+      the vendor to be blocked from download in embargoed or otherwise
+      sanctioned countries.
+    </p>
+    <p class="card-text">
+      The blocked ISO 3166 country codes can also be specified in the firmware
+      itself, using the <code>LVFS::BannedCountryCodes</code> metadata key.
+    </p>
+  </div>
+</div>
+
 {% endblock %}

--- a/app/templates/firmware-details.html
+++ b/app/templates/firmware-details.html
@@ -121,6 +121,13 @@
     <td class="col-sm-4">{{fw.version_display}}</td>
     <td class="col-sm-4"></td>
   </tr>
+{% if fw.banned_country_codes %}
+  <tr class="row">
+    <th class="col-sm-3">Banned Country Codes</th>
+    <td class="col-sm-4">{{fw.banned_country_codes}}</td>
+    <td class="col-sm-4"></td>
+  </tr>
+{% endif %}
   <tr class="row">
     <th class="col-sm-3">Downloads</th>
     <td class="col-sm-6">{{fw.download_cnt}}</td>

--- a/app/templates/vendor-details.html
+++ b/app/templates/vendor-details.html
@@ -46,6 +46,12 @@
            value="{{ v.username_glob if v.username_glob }}">
   </div>
   <div class="form-group">
+    <label for="display_name">Banned countries:</label>
+    <input type="text" class="form-control" name="banned_country_codes"
+           placeholder="ISO 3166 country codes, e.g. KP,CU,IR,SU,SY"
+           value="{{ v.banned_country_codes if v.banned_country_codes }}">
+  </div>
+  <div class="form-group">
     <label for="email">Description:</label>
     <input type="text" class="form-control" name="description" value="{{v.description}}" required>
   </div>

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -370,6 +370,10 @@ def upload():
             if pr:
                 md.protocol_id = pr.protocol_id
 
+        # allows OEM to set banned country codes
+        if 'LVFS::BannedCountryCodes' in metadata:
+            fw.banned_country_codes = metadata['LVFS::BannedCountryCodes']
+
     # add to database
     fw.events.append(FirmwareEvent(remote.remote_id, g.user.user_id))
     db.session.add(fw)

--- a/app/views_vendor.py
+++ b/app/views_vendor.py
@@ -351,6 +351,7 @@ def vendor_modify_by_admin(vendor_id):
                 'username_glob',
                 'version_format',
                 'url',
+                'banned_country_codes',
                 'keywords']:
         if key in request.form:
             setattr(vendor, key, request.form[key])

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -4,9 +4,14 @@ RUN yum -y update
 RUN yum -y install epel-release
 RUN yum -y install \
 	bsdtar \
+	geolite2-country \
 	libappstream-glib \
 	libgcab1 \
 	libstemmer \
+	GeoIP-devel \
+	gcc \
+	python-GeoIP \
+	python34-devel \
 	python34-gobject \
 	python34-pip \
 	python34-psutil \

--- a/migrations/versions/b298782e35cb_add_banned_country_codes.py
+++ b/migrations/versions/b298782e35cb_add_banned_country_codes.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: b298782e35cb
+Revises: 4641acfd71e3
+Create Date: 2019-03-12 12:56:26.191637
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b298782e35cb'
+down_revision = '4641acfd71e3'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('firmware', sa.Column('banned_country_codes', sa.Text(), nullable=True))
+    op.add_column('vendors', sa.Column('banned_country_codes', sa.Text(), nullable=True))
+
+def downgrade():
+    op.drop_column('vendors', 'banned_country_codes')
+    op.drop_column('firmware', 'banned_country_codes')

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyqrcode
 onetimepass
 PyGObject
 PyMySQL
+GeoIP


### PR DESCRIPTION
This is using the free GeoIP data and is optional, and best-effort.

To test, you need to do: yum install geolite2-country python-GeoIP