### PR TITLE
Allow specifying a device checksum in the metainfo.xml file

### DIFF
--- a/app/dbutils.py
+++ b/app/dbutils.py
@@ -136,6 +136,7 @@ def anonymize_db(db):
             continue
         for md in fw.mds:
             md.checksum_contents = hashlib.sha1(os.urandom(32)).hexdigest()
+            md.checksum_device = hashlib.sha1(os.urandom(32)).hexdigest()
             if md.name not in device_names_existing:
                 device_names_existing[md.name] = device_names[idx_device_names]
                 idx_device_names += 1

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -160,6 +160,13 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri=''):
                 csum.set('filename', md.filename_contents)
                 csum.set('target', 'content')
 
+            # add device checksum
+            if md.checksum_device:
+                csum = ET.SubElement(rel, 'checksum')
+                csum.text = md.checksum_device
+                csum.set('type', 'sha1')
+                csum.set('target', 'device')
+
             # add long description
             if md.release_description:
                 rel.append(_xml_from_markdown(md.release_description))

--- a/app/models.py
+++ b/app/models.py
@@ -515,6 +515,7 @@ class Component(db.Model):
     component_id = Column(Integer, primary_key=True, unique=True, nullable=False, index=True)
     firmware_id = Column(Integer, ForeignKey('firmware.firmware_id'), nullable=False, index=True)
     checksum_contents = Column(String(40), nullable=False)
+    checksum_device = Column(String(40), default=None)
     appstream_id = Column(Text, nullable=False)
     name = Column(Unicode, default=None)
     summary = Column(Unicode, default=None)
@@ -560,6 +561,7 @@ class Component(db.Model):
         self.name = None
         self.summary = None
         self.checksum_contents = None       # SHA1 of the firmware.bin
+        self.checksum_device = None         # SHA1 of the firmware on-device
         self.release_description = None
         self.release_timestamp = 0
         self.developer_name = None

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -17,3 +17,9 @@ input[type=checkbox] {
 .table-borderless th {
     border: 0;
 }
+
+input[type=text].fixed-width
+{
+    font-family: monospace;
+    font-size: 110%;
+}

--- a/app/templates/firmware-limits.html
+++ b/app/templates/firmware-limits.html
@@ -64,7 +64,7 @@
       <input type="number" class="form-control" name="value" min="1" max="10000" value="1000" required>
     </td>
     <td class="col-sm-3">
-      <input type="text" class="form-control" name="user_agent_glob" placeholder="*">
+      <input type="text" class="form-control fixed-width h-100" name="user_agent_glob" placeholder="*">
     </td>
     <td class="col-sm-4">
       <input type="text" class="form-control" name="response" placeholder="Too Many Requests">

--- a/app/templates/firmware-md-overview.html
+++ b/app/templates/firmware-md-overview.html
@@ -41,6 +41,21 @@
     <td class="col-sm-9">{{md.priority}}</td>
   </tr>
 {% endif %}
+  <form class="form-inline" method="post" action="/lvfs/component/{{md.component_id}}/modify" method="POST">
+  <tr class="row">
+    <th class="col-sm-3">Device Checksum</th>
+{% if md.fw.remote.name != 'stable' or g.user.check_acl('@admin') %}
+    <td class="col-sm-7">
+      <input type="text" class="form-control fixed-width" name="checksum_device" value="{{md.checksum_device if md.checksum_device}}"/>
+    </td>
+    <td class="col-sm-2">
+      <input type="submit" class="btn btn-secondary btn-block" value="Set"/>
+    </td>
+{% else %}
+    <td class="col-sm-7"><code>{{md.checksum_device}}</code></td>
+{% endif %}
+  </tr>
+  </form>
 {% if md.screenshot_url %}
   <form class="form-inline" method="post" action="/lvfs/component/{{md.component_id}}/modify" method="POST">
   <tr class="row">

--- a/app/templates/firmware-md-requires.html
+++ b/app/templates/firmware-md-requires.html
@@ -38,7 +38,7 @@
           <option value="glob" {{ 'selected' if rq and rq.compare == 'glob' }}>Glob</option>
           <option value="regex" {{ 'selected' if rq and rq.compare == 'regex' }}>Regular Expression</option>
         </select>
-        <input type="text" class="form-control" name="version" value="{{rq.version}}"/>
+        <input type="text" class="form-control fixed-width h-100" name="version" value="{{rq.version}}"/>
       </div>
 {% if md.check_acl('@modify-requirements') %}
       <div class="col-sm-2 text-right">
@@ -69,7 +69,7 @@
           <option value="glob" {{ 'selected' if rq and rq.compare == 'glob' }}>Glob</option>
           <option value="regex" {{ 'selected' if rq and rq.compare == 'regex' }}>Regular Expression</option>
         </select>
-        <input type="text" class="form-control" name="version" value="{{rq.version}}"/>
+        <input type="text" class="form-control fixed-width h-100" name="version" value="{{rq.version}}"/>
       </div>
 {% if md.check_acl('@modify-requirements') %}
        <div class="col-sm-2 text-right">
@@ -101,7 +101,7 @@
           <option value="glob" {{ 'selected' if rq and rq.compare == 'glob' }}>Glob</option>
           <option value="regex" {{ 'selected' if rq and rq.compare == 'regex' }}>Regular Expression</option>
         </select>
-        <input type="text" class="form-control" name="version" value="{{rq.version}}"/>
+        <input type="text" class="form-control fixed-width h-100" name="version" value="{{rq.version}}"/>
       </div>
 {% if md.check_acl('@modify-requirements') %}
       <div class="col-sm-2 text-right">
@@ -136,7 +136,7 @@
     <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
       <td class="col-sm-10">
         <input type="hidden" name="kind" value="hardware">
-        <input type="text" class="form-control" name="value" placeholder="b0f340b1-361e-55f9-b691-bc46d0921ea8"/>
+        <input type="text" class="form-control fixed-width" name="value" placeholder="b0f340b1-361e-55f9-b691-bc46d0921ea8"/>
         <p class="text-secondary">
           Add GUIDs here to restrict the update to a specific machine.
         </p>

--- a/app/views_component.py
+++ b/app/views_component.py
@@ -78,6 +78,15 @@ def firmware_component_all(component_id):
             break
     return render_template('device.html', fws=fws)
 
+def is_sha1(text):
+    if len(text) != 40:
+        return False
+    try:
+        _ = int(text, 16)
+    except ValueError:
+        return False
+    return True
+
 @app.route('/lvfs/component/<int:component_id>/modify', methods=['POST'])
 @login_required
 def firmware_component_modify(component_id):
@@ -96,6 +105,13 @@ def firmware_component_modify(component_id):
     page = 'overview'
     if 'screenshot_url' in request.form:
         md.screenshot_url = request.form['screenshot_url']
+    if 'checksum_device' in request.form:
+        checksum_device = request.form['checksum_device'].lower()
+        if not is_sha1(checksum_device):
+            flash('Invalid SHA1 hash: %s' % checksum_device, 'warning')
+            return redirect(url_for('.firmware_component_show',
+                                    component_id=md.component_id))
+        md.checksum_device = checksum_device
     if 'screenshot_caption' in request.form:
         md.screenshot_caption = _sanitize_markdown_text(request.form['screenshot_caption'])
     if 'install_duration' in request.form:

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -133,6 +133,12 @@ def _create_fw_from_uploaded_file(ufile):
         md.checksum_contents = csum.get_value()
         md.filename_contents = csum.get_filename()
 
+        # from the device checksum
+        if hasattr(AppStreamGlib.ChecksumTarget, 'DEVICE'):
+            csum = rel.get_checksum_by_target(AppStreamGlib.ChecksumTarget.DEVICE) # pylint: disable=no-member
+            if csum:
+                md.checksum_device = csum.get_value()
+
         # allows OEM to hide the direct download link on the LVFS
         metadata = component.get_metadata()
         if 'LVFS::InhibitDownload' in metadata:

--- a/migrations/versions/031e02cbc569_add_device_checksum.py
+++ b/migrations/versions/031e02cbc569_add_device_checksum.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 031e02cbc569
+Revises: 5bcdefe58b44
+Create Date: 2018-12-12 11:09:56.336055
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '031e02cbc569'
+down_revision = '5bcdefe58b44'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('components', sa.Column('checksum_device', sa.String(length=40), nullable=True))
+
+def downgrade():
+    op.drop_column('components', 'checksum_device')


### PR DESCRIPTION
Some firmware has a different on-device checksum to the hash of the firmware
file itself. This may be because:

 * The content is not a binary file, e.g. Intel HEX or SREC
 * Only part of the firmware is flashed, e.g. ignoring the bootloader section
 * The device checksum is calculated using another method entirely, e.g. PCR0