### PR TITLE
Add device name to page title

### DIFF
--- a/app/templates/device.html
+++ b/app/templates/device.html
@@ -1,5 +1,5 @@
 {% extends "default.html" %}
-{% block title %}Device{% endblock %}
+{% block title %}{{fws[0].mds[0].name if fws else 'No firmware for device found'}}{% endblock %}
 
 {% block nav %}{% include 'device-nav.html' %}{% endblock %}
 


### PR DESCRIPTION
This change adds currently displayed device name to the page title. Having device name there makes it easy to look for a previously visited device in browser history. This may also have a positive impact on search engine positioning.

I was considering an alternative where the most specific string is on the left (e.g. "XPS 13 9350 System Update - Device - LVFS") for when a page title is displayed in a shrunk page tab.

To be honest I didn't test this change but I reused the placeholder from device name so I hope it works :)

Thank you for taking the time to review this PR!