### PR TITLE
Show per-user and per-vendor event logs

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -99,6 +99,10 @@ class User(db.Model):
     fws = relationship('Firmware',
                        order_by="desc(Firmware.timestamp)",
                        primaryjoin='Firmware.user_id==User.user_id')
+    events = relationship("Event",
+                          order_by="desc(Event.timestamp)",
+                          lazy='dynamic',
+                          cascade='all,delete-orphan')
 
     def __init__(self, username, password=None, display_name=None,
                  vendor_id=None, auth_type='disabled', is_analyst=False, is_qa=False,
@@ -281,6 +285,10 @@ class Vendor(db.Model):
                                     back_populates="vendor")
     fws = relationship("Firmware",
                        cascade='all,delete-orphan')
+    events = relationship("Event",
+                          order_by="desc(Event.timestamp)",
+                          lazy='dynamic',
+                          cascade='all,delete-orphan')
 
     # link using foreign keys
     remote = relationship('Remote',

--- a/app/templates/user-event.html
+++ b/app/templates/user-event.html
@@ -1,0 +1,33 @@
+{% extends "default.html" %}
+{% block title %}User Event Log{% endblock %}
+
+{% block nav %}{% include 'user-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-2">Timestamp</th>
+    <th class="col-sm-2">Address</th>
+    <th class="col-sm-8">Message</th>
+  </tr>
+{% for e in u.events.limit(1000) %}
+  <tr class="row">
+    <td class="col-sm-2">{{e.timestamp}}</td>
+    <td class="col-sm-2"><code>{{e.address}}</code></td>
+    <td class="col-sm-8">
+{% if e.is_important %}
+      &#x272a;
+{% endif %}
+      {{e.message}}
+{% if e.request %}
+      <code>{{e.request}}</code>
+{% endif %}
+    </td>
+  </tr>
+{% endfor %}
+</table>
+
+{% endblock %}
+
+{% block breadcrumb %}{% include 'user-breadcrumb.html' %}{% endblock %}

--- a/app/templates/user-nav.html
+++ b/app/templates/user-nav.html
@@ -13,5 +13,8 @@
       <a class="nav-link {% if page == 'vendor' %}active{% endif %}" href="/lvfs/user/{{u.user_id}}/vendor">Change Vendor</a>
     </li>
 {% endif %}
+    <li class="nav-item">
+      <a class="nav-link {% if page == 'event' %}active{% endif %}" href="/lvfs/user/{{u.user_id}}/event">Event Log</a>
+    </li>
   </ul>
 </nav>

--- a/app/templates/vendor-event.html
+++ b/app/templates/vendor-event.html
@@ -1,0 +1,35 @@
+{% extends "default.html" %}
+{% block title %}Vendor Event Log{% endblock %}
+
+{% block nav %}{% include 'vendor-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-2">Timestamp</th>
+    <th class="col-sm-2">Address</th>
+    <th class="col-sm-3">User</th>
+    <th class="col-sm-5">Message</th>
+  </tr>
+{% for e in v.events.limit(1000) %}
+  <tr class="row">
+    <td class="col-sm-2">{{e.timestamp}}</td>
+    <td class="col-sm-2"><code>{{e.address}}</code></td>
+    <td class="col-sm-3">{{e.user.username}}</td>
+    <td class="col-sm-5">
+{% if e.is_important %}
+      &#x272a;
+{% endif %}
+      {{e.message}}
+{% if e.request %}
+      <code>{{e.request}}</code>
+{% endif %}
+    </td>
+  </tr>
+{% endfor %}
+</table>
+
+{% endblock %}
+
+{% block breadcrumb %}{% include 'vendor-breadcrumb.html' %}{% endblock %}

--- a/app/templates/vendor-nav.html
+++ b/app/templates/vendor-nav.html
@@ -23,5 +23,8 @@
       <a class="nav-link {% if request.url_rule.endpoint == 'vendor_affiliations' %}active{% endif %}" href="/lvfs/vendor/{{v.vendor_id}}/affiliations">Affiliates</a>
     </li>
 {% endif %}
+    <li class="nav-item">
+      <a class="nav-link {% if page == 'event' %}active{% endif %}" href="/lvfs/vendor/{{v.vendor_id}}/event">Event Log</a>
+    </li>
   </ul>
 </nav>

--- a/app/views_vendor.py
+++ b/app/views_vendor.py
@@ -212,6 +212,20 @@ def vendor_restrictions(vendor_id):
         return redirect(url_for('.vendor_list'), 302)
     return render_template('vendor-restrictions.html', v=vendor)
 
+@app.route('/lvfs/vendor/<int:vendor_id>/event')
+@login_required
+def vendor_event(vendor_id):
+    """ Allows changing a vendor """
+
+    # security check
+    vendor = db.session.query(Vendor).filter(Vendor.vendor_id == vendor_id).first()
+    if not vendor:
+        flash('Failed to get vendor details: No a vendor with that group ID', 'warning')
+        return redirect(url_for('.vendor_list'), 302)
+    if not vendor.check_acl('@manage-users'):
+        return _error_permission_denied('Unable to view event log')
+    return render_template('vendor-event.html', v=vendor, page='event')
+
 @app.route('/lvfs/vendor/<int:vendor_id>/users')
 @login_required
 def vendor_users(vendor_id):


### PR DESCRIPTION
With all the activity on the LVFS, it's not hugely useful to have one global
event log anymore.

Also, setting up a cascade relation between the event_log and the users table
means we can delete users without manually touching the database beforehand.