### PR TITLE
Show a detailed component requirement view when required

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -736,6 +736,19 @@ class Component(db.Model):
                                   page='update')
         return problems
 
+    @property
+    def has_complex_requirements(self):
+        seen = []
+        for rq in self.requirements:
+            if rq.kind == 'firmware':
+                if rq.value not in ['firmware', 'bootloader']:
+                    return True
+            key = rq.kind + ':' + rq.value
+            if key in seen:
+                return True
+            seen.append(key)
+        return False
+
     def add_keywords_from_string(self, value, priority=0):
         existing_keywords = {}
         for kw in self.keywords:

--- a/app/templates/component-nav.html
+++ b/app/templates/component-nav.html
@@ -12,7 +12,7 @@
       <a class="nav-link {% if page == 'update' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/update">Update Details</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link {% if page == 'requires' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/requires">Requirements</a>
+      <a class="nav-link {% if page in ['requires', 'requires-advanced'] %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/requires">Requirements</a>
     </li>
     <li class="nav-item">
       <a class="nav-link {% if page == 'keywords' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/keywords">Search Keywords</a>

--- a/app/templates/component-requires-advanced.html
+++ b/app/templates/component-requires-advanced.html
@@ -1,0 +1,166 @@
+{% extends "default.html" %}
+{% block title %}Firmware Component Details{% endblock %}
+
+{% block nav %}{% include 'component-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% if md.has_complex_requirements %}
+<div class="alert alert-warning mt-1" role="alert">
+  This firmware has complex requirements and care should be taken
+  when entering requirement values manually.
+</div>
+{% else %}
+<div class="alert alert-warning mt-1" role="alert">
+  Care should be taken when entering requirement values manually.
+</div>
+{% endif %}
+
+<h3 class="mt-3">AppStream IDs</h3>
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-6">Value</th>
+    <th class="col-sm-2">Compare</th>
+    <th class="col-sm-2">Version</th>
+    <th class="col-sm-2">&nbsp</th>
+  </tr>
+{% for rq in md.requirements %}
+{% if rq.kind == 'id' %}
+  <tr class="row">
+    <td class="col-sm-6">
+      <code>{{rq.value}}</code>
+    </td>
+    <td class="col-sm-2">
+      <code>{{rq.compare}}</code>
+    </td>
+    <td class="col-sm-2">
+      <code>{{rq.version}}</code>
+    </td>
+    <td class="col-sm-2 text-right">
+      <a class="btn btn-secondary btn-block" href="/lvfs/component/{{rq.md.component_id}}/requirement/delete/{{rq.requirement_id}}" role="button">Remove</a>
+    </td>
+  </tr>
+{% endif %}
+{% endfor %}
+{% if md.check_acl('@modify-requirements') %}
+  <tr class="row table-borderless">
+    <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+      <td class="col-sm-6">
+        <input type="hidden" name="kind" value="id">
+        <input type="text" class="form-control fixed-width" name="value" placeholder="org.freedesktop.fwupd"/>
+      </td>
+      <td class="col-sm-2">
+        <select class="form-control" name="compare">
+          <option value="eq" selected>Exactly</option>
+          <option value="ne">Not equal</option>
+          <option value="ge">Greater than or equal</option>
+          <option value="gt">Greater than</option>
+          <option value="le">Less than or equal</option>
+          <option value="lt">Less than</option>
+          <option value="glob">Glob</option>
+          <option value="regex">Regular Expression</option>
+        </select>
+      </td>
+      <td class="col-sm-2">
+        <input type="text" class="form-control" name="version" placeholder="1.2.3"/>
+      </td>
+      <td class="col-sm-2">
+        <input type="submit" class="btn btn-primary btn-block" value="Add"/>
+      </td>
+    </form>
+  </tr>
+{% endif %}
+</table>
+
+<h3 class="mt-3">Firmware</h3>
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-6">Value</th>
+    <th class="col-sm-2">Compare</th>
+    <th class="col-sm-2">Version</th>
+    <th class="col-sm-2">&nbsp</th>
+  </tr>
+{% for rq in md.requirements %}
+{% if rq.kind == 'firmware' %}
+  <tr class="row">
+    <td class="col-sm-6">
+      <code>{{rq.value}}</code>
+    </td>
+    <td class="col-sm-2">
+      <code>{{rq.compare}}</code>
+    </td>
+    <td class="col-sm-2">
+      <code>{{rq.version}}</code>
+    </td>
+    <td class="col-sm-2 text-right">
+      <a class="btn btn-secondary btn-block" href="/lvfs/component/{{rq.md.component_id}}/requirement/delete/{{rq.requirement_id}}" role="button">Remove</a>
+    </td>
+  </tr>
+{% endif %}
+{% endfor %}
+{% if md.check_acl('@modify-requirements') %}
+  <tr class="row table-borderless">
+    <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+      <td class="col-sm-6">
+        <input type="hidden" name="kind" value="firmware">
+        <input type="text" class="form-control fixed-width" name="value" placeholder="firmware"/>
+      </td>
+      <td class="col-sm-2">
+        <select class="form-control" name="compare">
+          <option value="eq" selected>Exactly</option>
+          <option value="ne">Not equal</option>
+          <option value="ge">Greater than or equal</option>
+          <option value="gt">Greater than</option>
+          <option value="le">Less than or equal</option>
+          <option value="lt">Less than</option>
+          <option value="glob">Glob</option>
+          <option value="regex">Regular Expression</option>
+        </select>
+      </td>
+      <td class="col-sm-2">
+        <input type="text" class="form-control" name="version" placeholder="1.2.3"/>
+      </td>
+      <td class="col-sm-2">
+        <input type="submit" class="btn btn-primary btn-block" value="Add"/>
+      </td>
+    </form>
+  </tr>
+{% endif %}
+</table>
+
+<h3 class="mt-3">Computer Hardware IDs</h3>
+<table class="table">
+{% for rq in md.requirements %}
+{% if rq.kind == 'hardware' %}
+  <tr class="row">
+    <td class="col-sm-10">
+      <code>{{rq.value}}</code>
+    </td>
+    <td class="col-sm-2 text-right">
+      <a class="btn btn-secondary btn-block" href="/lvfs/component/{{rq.md.component_id}}/requirement/delete/{{rq.requirement_id}}" role="button">Remove</a>
+    </td>
+  </tr>
+{% endif %}
+{% endfor %}
+{% if md.check_acl('@modify-requirements') %}
+  <tr class="row table-borderless">
+    <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/modify" method="POST" >
+      <td class="col-sm-10">
+        <input type="hidden" name="kind" value="hardware">
+        <input type="text" class="form-control fixed-width" name="value" placeholder="b0f340b1-361e-55f9-b691-bc46d0921ea8"/>
+      </td>
+      <td class="col-sm-2">
+        <input type="submit" class="btn btn-primary btn-block" value="Add"/>
+      </td>
+    </form>
+  </tr>
+{% endif %}
+</table>
+
+{% if not md.has_complex_requirements %}
+<a class="btn btn-info" href="{{url_for('.firmware_component_show', component_id=md.component_id, page='requires')}}">Show simple view</a>
+{% endif %}
+
+{% endblock %}
+
+{% block breadcrumb %}{% include 'component-breadcrumb.html' %}{% endblock %}

--- a/app/templates/component-requires.html
+++ b/app/templates/component-requires.html
@@ -12,7 +12,7 @@
 </div>
 {% endif %}
 {% endif %}
-<form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+<form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/modify" method="POST" >
   <input type="hidden" name="kind" value="firmware">
   <input type="hidden" name="value" value="bootloader">
   <div class="table">
@@ -36,14 +36,14 @@
       </div>
 {% if md.check_acl('@modify-requirements') %}
       <div class="col-sm-2 text-right">
-        <input type="submit" class="btn btn-secondary btn-block" value="Set"/>
+        <input type="submit" class="btn btn-primary btn-block" value="Set"/>
       </div>
 {% endif %}
     </div>
   </div>
 </form>
 
-<form class="form-inline mt-2" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+<form class="form-inline mt-2" action="/lvfs/component/{{md.component_id}}/requirement/modify" method="POST" >
   <input type="hidden" name="kind" value="firmware">
   <input type="hidden" name="value" value="firmware">
   <div class="table">
@@ -67,7 +67,7 @@
       </div>
 {% if md.check_acl('@modify-requirements') %}
        <div class="col-sm-2 text-right">
-        <input type="submit" class="btn btn-secondary btn-block" value="Set"/>
+        <input type="submit" class="btn btn-primary btn-block" value="Set"/>
       </div>
 {% endif %}
     </div>
@@ -75,7 +75,7 @@
 </form>
 
 <h3 class="mt-3">Computer Software Versions</h3>
-<form class="form-inline mt-2" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+<form class="form-inline mt-2" action="/lvfs/component/{{md.component_id}}/requirement/modify" method="POST" >
   <input type="hidden" name="kind" value="id">
   <input type="hidden" name="value" value="org.freedesktop.fwupd">
   <div class="table">
@@ -99,7 +99,7 @@
       </div>
 {% if md.check_acl('@modify-requirements') %}
       <div class="col-sm-2 text-right">
-        <input type="submit" class="btn btn-secondary btn-block" value="Set"/>
+        <input type="submit" class="btn btn-primary btn-block" value="Set"/>
       </div>
 {% endif %}
     </div>
@@ -115,7 +115,7 @@
       <code>{{rq.value}}</code>
     </td>
     <td class="col-sm-2 text-right">
-      <a class="btn btn-secondary" href="/lvfs/component/{{rq.md.component_id}}/requirement/delete/{{rq.requirement_id}}" role="button">&ndash;</a>
+      <a class="btn btn-secondary btn-block" href="/lvfs/component/{{rq.md.component_id}}/requirement/delete/{{rq.requirement_id}}" role="button">Remove</a>
     </td>
   </tr>
 {% endif %}
@@ -127,7 +127,7 @@
 {% endif %}
 {% if md.check_acl('@modify-requirements') %}
   <tr class="row table-borderless">
-    <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/add" method="POST" >
+    <form class="form-inline" action="/lvfs/component/{{md.component_id}}/requirement/modify" method="POST" >
       <td class="col-sm-10">
         <input type="hidden" name="kind" value="hardware">
         <input type="text" class="form-control fixed-width" name="value" placeholder="b0f340b1-361e-55f9-b691-bc46d0921ea8"/>
@@ -136,12 +136,17 @@
         </p>
       </td>
       <td class="col-sm-2">
-        <input type="submit" class="btn btn-secondary btn-block" value="Add"/>
+        <input type="submit" class="btn btn-primary btn-block" value="Add"/>
       </td>
     </form>
   </tr>
 {% endif %}
 </table>
+
+{% if md.requirements %}
+<a class="btn btn-info" href="{{url_for('.firmware_component_show', component_id=md.component_id, page='requires-advanced')}}">Show detailed view</a>
+{% endif %}
+
 {% endblock %}
 
 {% block breadcrumb %}{% include 'component-breadcrumb.html' %}{% endblock %}

--- a/lvfs_test.py
+++ b/lvfs_test.py
@@ -969,14 +969,14 @@ class LvfsTestCase(unittest.TestCase):
         assert b'Removed requirement 85d38fda-fc0e-5c6f-808f-076984ae7978' in rv.data, rv.data
 
         # add an invalid CHID
-        rv = self.app.post('/lvfs/component/1/requirement/add', data=dict(
+        rv = self.app.post('/lvfs/component/1/requirement/modify', data=dict(
             kind='hardware',
             value='NOVALIDGUID',
         ), follow_redirects=True)
         assert b'NOVALIDGUID is not a valid GUID' in rv.data, rv.data
 
         # add a valid CHID
-        rv = self.app.post('/lvfs/component/1/requirement/add', data=dict(
+        rv = self.app.post('/lvfs/component/1/requirement/modify', data=dict(
             kind='hardware',
             value='85d38fda-fc0e-5c6f-808f-076984ae7978',
         ), follow_redirects=True)
@@ -984,7 +984,7 @@ class LvfsTestCase(unittest.TestCase):
         assert b'Added requirement' in rv.data, rv.data
 
         # modify an existing requirement by adding it again
-        rv = self.app.post('/lvfs/component/1/requirement/add', data=dict(
+        rv = self.app.post('/lvfs/component/1/requirement/modify', data=dict(
             kind='id',
             value='org.freedesktop.fwupd',
             compare='ge',
@@ -994,7 +994,7 @@ class LvfsTestCase(unittest.TestCase):
         assert b'Modified requirement' in rv.data, rv.data
 
         # delete a requirement by adding an 'any' comparison
-        rv = self.app.post('/lvfs/component/1/requirement/add', data=dict(
+        rv = self.app.post('/lvfs/component/1/requirement/modify', data=dict(
             kind='id',
             value='org.freedesktop.fwupd',
             compare='any',


### PR DESCRIPTION
For the uncommon case of a firmware with a GUID requirement, or where a version
range is required switch to an 'advanced' table view that allows the user to
both view all existing requirements and to add more.

Fixes https://github.com/hughsie/lvfs-website/issues/221