### PR TITLE
Perform 'offline' runtime checks on uploaded firmware

### DIFF
--- a/app/pluginloader.py
+++ b/app/pluginloader.py
@@ -184,6 +184,17 @@ class Pluginloader(object):
                 except PluginError as e:
                     _event_log('Plugin %s failed for ArchiveFinalize(): %s' % (plugin.id, str(e)))
 
+    # ensure an assay is added for the component
+    def ensure_assay_for_md(self, md):
+        if not self.loaded:
+            self.load_plugins()
+        for plugin in self._plugins:
+            if hasattr(plugin, 'ensure_assay_for_md'):
+                try:
+                    plugin.ensure_assay_for_md(md)
+                except PluginError as e:
+                    _event_log('Plugin %s failed for ensure_assay_for_md(): %s' % (plugin.id, str(e)))
+
     # log out of all oauth providers
     def oauth_logout(self):
         if not self.loaded:

--- a/app/templates/component-assays.html
+++ b/app/templates/component-assays.html
@@ -1,0 +1,60 @@
+{% extends "default.html" %}
+{% block title %}Assays{% endblock %}
+
+{% block nav %}{% include 'component-nav.html' %}{% endblock %}
+
+{% block content %}
+<table class="table">
+{% if md.assays|length > 0 %}
+  <tr class="row table-borderless">
+    <th class="col-sm-3">Plugin ID</th>
+    <th class="col-sm-7">Details</th>
+    <th class="col-sm-2"></th>
+  </tr>
+{% for assay in md.assays %}
+  <tr class="row">
+    <td class="col-sm-3">
+      <code>{{assay.plugin_id}}</code>
+    </td>
+    <td class="col-sm-7">
+      <ul class="list-group">
+{% if not assay.started_ts %}
+        <li class="list-group-item list-group-item-warning">Test is pending…</li>
+{% elif not assay.ended_ts %}
+        <li class="list-group-item list-group-item-info">Test is running since {{assay.started_ts}}…</li>
+{% endif %}
+{% for attr in assay.attributes %}
+        <li class="list-group-item {{'list-group-item-success' if attr.success else 'list-group-item-danger'}}">
+          <code>{{attr.title}}: {{attr.message}}</code>
+        </li>
+{% endfor %}
+{% if assay.waived_ts %}
+        <li class="list-group-item list-group-item-warning">
+          Waived by <code>{{assay.waived_user.username}}</code>
+        </li>
+{% endif %}
+      </ul>
+    </td>
+    <td class="col-sm-2 text-right">
+{% if assay.started_ts and assay.check_acl('@retry') %}
+      <a class="btn btn-info btn-block"
+         href="{{url_for('.firmware_assay_retry', component_id=md.component_id, assay_id=assay.assay_id)}}"
+         role="button">Retry</a>
+{% endif %}
+{% if assay.ended_ts and assay.waivable and not assay.waived_ts and assay.check_acl('@waive') %}
+      <a class="btn btn-warning btn-block"
+         href="{{url_for('.firmware_assay_waive', component_id=md.component_id, assay_id=assay.assay_id)}}"
+         role="button">Waive</a>
+{% endif %}
+    </td>
+  </tr>
+{% endfor %}
+</table>
+{% else %}
+<p class="text-secondary">
+  No tests are required.
+</p>
+{% endif %}
+{% endblock %}
+
+{% block breadcrumb %}{% include 'component-breadcrumb.html' %}{% endblock %}

--- a/app/templates/component-nav.html
+++ b/app/templates/component-nav.html
@@ -3,6 +3,11 @@
     <li class="nav-item">
       <a class="nav-link {% if page == 'overview' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}">Overview</a>
     </li>
+{% if md.assays|length > 0 %}
+    <li class="nav-item">
+      <a class="nav-link {% if page == 'assays' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/assays">Tests</a>
+    </li>
+{% endif %}
 {% if md.protocol and md.protocol.can_verify %}
     <li class="nav-item">
       <a class="nav-link {% if page == 'checksums' %}active{% endif %}" href="/lvfs/component/{{md.component_id}}/checksums">Device Checksums</a>

--- a/app/templates/firmware-problems.html
+++ b/app/templates/firmware-problems.html
@@ -82,6 +82,24 @@
         can be moved to a different target.
       </p>
     </td>
+{% elif problem.kind == 'assay-pending' %}
+    <td class="col-sm-7">
+      <p class="card-text">
+        The LVFS runs tests on certain types of firmware to check they are valid.
+        Some tests are still pending and will be completed shortly.
+        You can refresh this page to find out when the firmware has been tested.
+      </p>
+    </td>
+{% elif problem.kind == 'assay-failed' %}
+    <td class="col-sm-7">
+      <p class="card-text">
+        A check on the firmware has failed.
+        Some checks can be <em>waived</em> by a QA user and ignored.
+      </p>
+      <p class="card-text">
+        <code>{{problem.description}}</code>
+      </p>
+    </td>
 {% else %}
     <td class="col-sm-7">
       <p class="card-text">

--- a/app/util.py
+++ b/app/util.py
@@ -23,6 +23,7 @@ from flask import request, flash, render_template, g, Response
 import gi
 gi.require_version('GCab', '1.0')
 from gi.repository import GCab
+from gi.repository import Gio
 from gi.repository import GLib
 
 def _unwrap_xml_text(txt):
@@ -295,3 +296,20 @@ def _email_check(value):
 
 def _generate_password(size=10, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
+
+def _get_firmware_contents_from_archive(md):
+    from app import app
+    fn = os.path.join(app.config['DOWNLOAD_DIR'], md.fw.filename)
+    try:
+        istream = Gio.File.new_for_path(fn).read()
+    except gi.repository.GLib.Error as e: # pylint: disable=catching-non-exception
+        raise RuntimeError(e)
+    cfarchive = GCab.Cabinet.new()
+    cfarchive.load(istream)
+    cfarchive.extract(None)
+
+    cfs = _archive_get_files_from_glob(cfarchive, md.filename_contents)
+    if not cfs or len(cfs) > 1:
+        raise RuntimeError('file not found in archive')
+
+    return cfs[0].get_bytes().get_data()

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -359,6 +359,11 @@ def upload():
     fw.events.append(FirmwareEvent(remote.remote_id, g.user.user_id))
     db.session.add(fw)
     db.session.commit()
+
+    # ensure the assay has been added for the firmware type
+    for md in fw.mds:
+        ploader.ensure_assay_for_md(md)
+
     flash('Uploaded file %s to %s' % (ufile.filename_new, target), 'info')
 
     # invalidate

--- a/migrations/versions/c3d10b2a239c_add_assays.py
+++ b/migrations/versions/c3d10b2a239c_add_assays.py
@@ -1,0 +1,47 @@
+"""
+
+Revision ID: c3d10b2a239c
+Revises: a79dd3da286b
+Create Date: 2019-01-10 14:25:35.915843
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c3d10b2a239c'
+down_revision = 'a79dd3da286b'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.create_table('assays',
+    sa.Column('assay_id', sa.Integer(), nullable=False),
+    sa.Column('component_id', sa.Integer(), nullable=False),
+    sa.Column('plugin_id', sa.Text(), nullable=True),
+    sa.Column('waivable', sa.Boolean(), nullable=True),
+    sa.Column('started_ts', sa.DateTime(), nullable=True),
+    sa.Column('ended_ts', sa.DateTime(), nullable=True),
+    sa.Column('waived_ts', sa.DateTime(), nullable=True),
+    sa.Column('waived_user_id', sa.Integer(), nullable=True),
+    sa.ForeignKeyConstraint(['component_id'], ['components.component_id'], ),
+    sa.ForeignKeyConstraint(['waived_user_id'], ['users.user_id'], ),
+    sa.PrimaryKeyConstraint('assay_id'),
+    sa.UniqueConstraint('assay_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_table('assay_attributes',
+    sa.Column('assay_attribute_id', sa.Integer(), nullable=False),
+    sa.Column('assay_id', sa.Integer(), nullable=False),
+    sa.Column('title', sa.Text(), nullable=False),
+    sa.Column('message', sa.Text(), nullable=True),
+    sa.Column('success', sa.Boolean(), nullable=True),
+    sa.ForeignKeyConstraint(['assay_id'], ['assays.assay_id'], ),
+    sa.PrimaryKeyConstraint('assay_attribute_id'),
+    sa.UniqueConstraint('assay_attribute_id'),
+    mysql_character_set='utf8mb4'
+    )
+
+def downgrade():
+    op.drop_table('assay_attributes')
+    op.drop_table('assays')

--- a/plugins/uefi-capsule/__init__.py
+++ b/plugins/uefi-capsule/__init__.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+#
+# pylint: disable=no-self-use
+
+from __future__ import print_function
+
+import os
+import struct
+import uuid
+
+from app.pluginloader import PluginBase, PluginError, PluginSettingBool
+from app.util import _get_firmware_contents_from_archive, _get_settings
+from app.models import Assay
+
+class Plugin(PluginBase):
+    def __init__(self):
+        PluginBase.__init__(self)
+
+    def name(self):
+        return 'UEFI Capsule'
+
+    def summary(self):
+        return 'Check the UEFI capsule header and file structure'
+
+    def settings(self):
+        s = []
+        s.append(PluginSettingBool('uefi_capsule_check_header', 'Check Header', True))
+        return s
+
+    def ensure_assay_for_md(self, md):
+
+        # get settings
+        settings = _get_settings('uefi_capsule_check_header')
+        if settings['uefi_capsule_check_header'] != 'enabled':
+            return
+
+        # only run for capsule updates
+        if not md.protocol:
+            return
+        if md.protocol.value != 'org.uefi.capsule':
+            return
+
+        # add if not already exists
+        assay = md.find_assay_by_plugin_id(self.id)
+        if not assay:
+            assay = Assay(self.id, waivable=True)
+            md.assays.append(assay)
+
+    def run_assay_on_md(self, assay, md):
+
+        # get settings
+        settings = _get_settings('uefi_capsule_check_header')
+        if settings['uefi_capsule_check_header'] != 'enabled':
+            return
+
+        # decompress firmware
+        try:
+            contents = _get_firmware_contents_from_archive(md)
+        except RuntimeError as e:
+            assay.add_fail('Open', 'Cannot load %s: %s' % (md.filename_contents, str(e)))
+            # we have to abort here, no further tests are possible
+            return
+
+        # unpack the header
+        try:
+            data = struct.unpack('<16sIII', contents[:28])
+        except struct.error as e:
+            assay.add_fail('FileSize', len(contents))
+            # we have to abort here, no further tests are possible
+            return
+
+        # check the GUID
+        guid = str(uuid.UUID(bytes_le=data[0]))
+        referenced_guids = []
+        for gu in md.guids:
+            referenced_guids.append(gu.value)
+        if guid == '00000000-0000-0000-0000-000000000000':
+            assay.add_fail('GUID', '%s is not valid' % guid)
+        elif guid in referenced_guids:
+            assay.add_pass('GUID', guid)
+        else:
+            assay.add_fail('GUID', '%s not found in %s' % (guid, referenced_guids))
+
+        # check the header size
+        if data[1] % 4096 == 0:
+            assay.add_pass('HeaderSize', data[1])
+        else:
+            assay.add_fail('HeaderSize', '0x%x not aligned to 4kB' % data[1])
+
+        # check if the flags are sane
+        CAPSULE_FLAGS_PERSIST_ACROSS_RESET = 0x00010000
+        CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE = 0x00020000
+        CAPSULE_FLAGS_INITIATE_RESET = 0x00040000
+        if data[2] & CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE > 0 and \
+           data[2] & CAPSULE_FLAGS_PERSIST_ACROSS_RESET == 0:
+            assay.add_fail('Flags', '0x%x -- POPULATE_SYSTEM_TABLE requires PERSIST_ACROSS_RESET' % data[2])
+        elif data[2] & CAPSULE_FLAGS_INITIATE_RESET > 0 and \
+             data[2] & CAPSULE_FLAGS_PERSIST_ACROSS_RESET == 0:
+            assay.add_fail('Flags', '0x%x -- INITIATE_RESET requires PERSIST_ACROSS_RESET' % data[2])
+        else:
+            assay.add_pass('Flags', '0x%x' % data[2])
+
+        # check the capsule image size
+        if data[3] == len(contents):
+            assay.add_pass('CapsuleImageSize', data[3])
+        else:
+            assay.add_fail('CapsuleImageSize',
+                           '0x%x does not match file size 0x%x' % (data[3], len(contents)))


### PR DESCRIPTION
Initially, add a simple plugin that checks the UEFI capsule header. Later we
could add further firmware analysis like uefi-firmware-parser or perhaps even
something like CHIPSEC.

Running this as a cron job every 5 minutes means the main uWSGI thread is not
waiting for the result, which means we could even do a malware scan which takes
a minute or two to complete.

Failures in the assay means a problem is added to the firmware, which prevents
it being moved to testing and stable. Some failures are waivable by a QA user
which means a problem is no longer generated.