### PR TITLE
Simplify cross/tick icons to make them display in Firefox

### DIFF
--- a/app/static/img/cross.svg
+++ b/app/static/img/cross.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
-	.st0{clip-path:url(#SVGID_2_);fill:none;stroke:#E44061;stroke-width:45;}
-	.st1{fill:#E44061;}
-</style><g><g><defs><rect height="512" id="SVGID_1_" width="512" x="50" y="140"/></defs><clipPath id="SVGID_2_"><use style="overflow:visible;" xlink:href="#SVGID_1_"/></clipPath><path class="st0" d="M306,629.5c128.8,0,233.5-104.7,233.5-233.5S434.8,162.5,306,162.5S72.5,267.2,72.5,396    S177.2,629.5,306,629.5L306,629.5z"/></g><polygon class="st1" points="348.7,396 448,296.7 405.3,254 306,353.3 206.7,254 164,296.7 263.3,396 164,495.3 206.7,538    306,438.7 405.3,538 448,495.3 348.7,396  "/></g></svg>
+<svg version="1.1" viewBox="0 0 612 792" xmlns="http://www.w3.org/2000/svg">
+  <path d="m306 629.5c128.8 0 233.5-104.7 233.5-233.5s-104.7-233.5-233.5-233.5-233.5 104.7-233.5 233.5 104.7 233.5 233.5 233.5z" fill="none" stroke="#e44061" stroke-width="45"/>
+  <polygon class="st1" points="405.3 254 306 353.3 206.7 254 164 296.7 263.3 396 164 495.3 206.7 538 306 438.7 405.3 538 448 495.3 348.7 396 448 296.7" fill="#e44061"/>
+</svg>

--- a/app/static/img/tick.svg
+++ b/app/static/img/tick.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
-	.st0{clip-path:url(#SVGID_2_);fill:none;stroke:#41AD49;stroke-width:45;}
-	.st1{fill:#41AD49;}
-</style><g><g><defs><rect height="512" id="SVGID_1_" width="512" x="50" y="140"/></defs><clipPath id="SVGID_2_"><use style="overflow:visible;" xlink:href="#SVGID_1_"/></clipPath><path class="st0" d="M306,629.5c128.8,0,233.5-104.7,233.5-233.5S434.8,162.5,306,162.5S72.5,267.2,72.5,396    S177.2,629.5,306,629.5L306,629.5z"/></g><polygon class="st1" points="421.4,271 241.9,450.5 174.9,383.5 122,436.4 241.9,556.2 257.3,540.8 257.4,540.8 474.3,323.9    421.4,271  "/></g></svg>
+<svg version="1.1" viewBox="0 0 612 792" xmlns="http://www.w3.org/2000/svg">
+  <path class="st0" d="m306 629.5c128.8 0 233.5-104.7 233.5-233.5s-104.7-233.5-233.5-233.5-233.5 104.7-233.5 233.5 104.7 233.5 233.5 233.5z" fill="none" stroke="#41ad49" stroke-width="45"/>
+  <polygon class="st1" points="174.9 383.5 122 436.4 241.9 556.2 257.3 540.8 257.4 540.8 474.3 323.9 421.4 271 241.9 450.5" fill="#41ad49"/>
+</svg>


### PR DESCRIPTION
Closes #270.

Apparently, the `clip-path` inside the embedded styles are considered harmful in Firefox's CSRF protection. Since the icons are really simple, those embedded styles are not really needed either.

This simplification should make them display correctly. (I couldn't test that because CSRF protection is disabled for `http://localhost` / `file://`.)