### PR TITLE
Add a page showing new firmware on the LVFS

### DIFF
--- a/app/templates/default.html
+++ b/app/templates/default.html
@@ -53,6 +53,7 @@
               <a class="dropdown-item" href="{{url_for('.docs_telemetry')}}">Telemetry</a>
               <a class="dropdown-item" href="{{url_for('.docs_affiliates')}}">Affiliates</a>
               <div class="dropdown-divider"></div>
+              <a class="dropdown-item" href="{{url_for('.firmware_new')}}">New Firmware</a>
               <a class="dropdown-item" href="{{url_for('.device_list')}}">Supported Devices</a>
               <a class="dropdown-item" href="{{url_for('.vendor_list')}}">Vendor List</a>
               <a class="dropdown-item" href="{{url_for('.docs_donations')}}">Donating to the LVFS</a>

--- a/app/templates/firmware-new.html
+++ b/app/templates/firmware-new.html
@@ -1,0 +1,38 @@
+{% extends "default.html" %}
+{% block title %}New Firmware{% endblock %}
+
+{% block content %}
+<h1>New Firmware</h1>
+<p>
+  This list show the last {{limit}} public firmwares available on the LVFS.
+</p>
+
+{% if fwevs|length == 0 %}
+<p class="text-muted">
+  No firmware has been uploaded yet.
+{% else %}
+<table class="table">
+  <tr class="row">
+    <th class="col-sm-2">When</th>
+    <th class="col-sm-5">Hardware</th>
+    <th class="col-sm-3">Version</th>
+    <th class="col-sm-2">&nbsp;</th>
+  </tr>
+{% for fwev in fwevs %}
+  <tr class="row">
+    <td class="col-sm-2">{{format_humanize_naturaltime(fwev.timestamp)}}</td>
+    <td class="col-sm-5">
+      {{fwev.fw.mds[0].developer_name_display}}
+      {{fwev.fw.mds[0].name_display}}
+    </td>
+    <td class="col-sm-3">{{fwev.fw.version_display}}</td>
+    <td class="col-sm-2">
+      <a href="/lvfs/device/{{fwev.fw.mds[0].guids[0].value}}"
+         class="btn btn-info btn-block">Details</a>
+    </td>
+  </tr>
+{% endfor %}
+</table>
+{% endif %}
+
+{% endblock %}

--- a/app/views_firmware.py
+++ b/app/views_firmware.py
@@ -61,6 +61,25 @@ def firmware(show_all=False):
 def firmware_all():
     return firmware(True)
 
+@app.route('/lvfs/firmware/new')
+@app.route('/lvfs/firmware/new/<int:limit>')
+def firmware_new(limit=200):
+
+    # get a sorted list of vendors
+    fwevs = db.session.query(FirmwareEvent).\
+                order_by(FirmwareEvent.timestamp.desc()).\
+                limit(limit).all()
+    fwevs_public = []
+    fws = []
+    for fwev in fwevs:
+        if not fwev.fw.remote.name == 'stable':
+            continue
+        if fwev.fw in fws:
+            continue
+        fwevs_public.append(fwev)
+        fws.append(fwev.fw)
+    return render_template('firmware-new.html', fwevs=fwevs_public, limit=limit)
+
 @app.route('/lvfs/firmware/<int:firmware_id>/undelete')
 @login_required
 def firmware_undelete(firmware_id):


### PR DESCRIPTION
I'm often asked this, and from a personal point of view it's easier in a list
than sorting through the event log and checking which firmware is in testing or
stable.