### PR TITLE
Store the device checksums in the database correctly

### DIFF
--- a/app/views_report.py
+++ b/app/views_report.py
@@ -120,8 +120,11 @@ def firmware_report():
                 for md_key in md:
                     data[md_key] = md[md_key]
                 continue
-            #data[key] = str(report[key]).encode('ascii', 'ignore')
-            data[key] = report[key]
+            # allow array of strings for any of the keys
+            if isinstance(report[key], list):
+                data[key] = ','.join(report[key])
+            else:
+                data[key] = report[key]
 
         # try to find the checksum_upload (which might not exist on this server)
         fw = db.session.query(Firmware).filter(Firmware.checksum_signed == report['Checksum']).first()


### PR DESCRIPTION
In https://github.com/hughsie/fwupd/commit/06ef7f7e46b79e840e176f913f54b58fbc948c6a
I stated the LVFS doesn't use the ChecksumDevice data. It turns out we do,
but only to count...

In case we start using the checksum in a cleverer way in the future don't store
the Python list.__str__ output in the db, converting all lists the same way.