### PR TITLE
Do not crash when parsing invalid metainfo files with invalid UTF-8

### DIFF
--- a/app/uploadedfile.py
+++ b/app/uploadedfile.py
@@ -207,11 +207,15 @@ class UploadedFile:
 
         component = AppStreamGlib.App.new()
         try:
+            # check this is valid UTF-8
+            cf.get_bytes().get_data().decode('utf-8')
             component.parse_data(cf.get_bytes(), AppStreamGlib.AppParseFlags.NONE)
             fmt = AppStreamGlib.Format.new()
             fmt.set_kind(AppStreamGlib.FormatKind.METAINFO)
             component.add_format(fmt)
             component.validate(AppStreamGlib.AppValidateFlags.NONE)
+        except UnicodeDecodeError as e:
+            raise MetadataInvalid('The metadata %s could not be parsed: %s' % (cf.get_name(), str(e)))
         except Exception as e:
             try:
                 msg = e.message.decode('utf-8')


### PR DESCRIPTION
The arguably more correct fix would be to update GLib to a newer version, but
that's somewhat hard for the version of RHEL-7 in production.

Just check the data before we call into GObjectIntrospection.