### PR TITLE
correct the number of splits when parsing certtool

### DIFF
--- a/app/util.py
+++ b/app/util.py
@@ -401,7 +401,7 @@ def _pkcs7_signature_verify(certificate, payload, signature):
         raise IOError(err)
     for line in err.decode('utf8').split('\n'):
         try:
-            key, value = line.strip().split(':', 2)
+            key, value = line.strip().split(':', 1)
             print(key, value)
             if key == 'Signature status':
                 status = value.strip()


### PR DESCRIPTION
This should only break the line into two parts, so 1 should be used as the number of splits. Set to 2, the code raises ValueError when parsing "Signature status: verification failed: Public key signature verification has failed.". Without this change I think it would be slightly easier to pull off something like CVE-2018-12020 as an attacker.

I haven't tested running the app with this change. I really just wanted to comment - feel free to deny this PR.