### PR TITLE
Add a component property to express the firmware style

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,4 +99,5 @@ from app import views_issue
 from app import views_search
 from app import views_agreement
 from app import views_protocol
+from app import views_category
 from app import views_test

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
 # Licensed under the GNU General Public License Version 2
 #
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements,too-many-locals,too-many-nested-blocks
 
 import os
 import hashlib
@@ -42,7 +42,8 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri='', local=False):
         component = ET.SubElement(root, 'component')
         component.set('type', 'firmware')
         ET.SubElement(component, 'id').text = md.appstream_id
-        ET.SubElement(component, 'name').text = md.name
+        # until all front ends support <category> append the suffix */
+        ET.SubElement(component, 'name').text = md.name_with_category
         ET.SubElement(component, 'summary').text = md.summary
         ET.SubElement(component, 'developer_name').text = md.developer_name
         if md.description:
@@ -200,6 +201,23 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri='', local=False):
                 sz = ET.SubElement(rel, 'size')
                 sz.set('type', 'download')
                 sz.text = str(md.release_download_size)
+
+        # deliberately not including <category> here until 2020-01-01
+        if False:                       # pylint: disable=using-constant-test
+            cats = []
+            for md in mds:
+                if not md.category:
+                    continue
+                if md.category.value not in cats:
+                    cats.append(md.category.value)
+                if md.category.fallbacks:
+                    for fallback in md.category.fallbacks.split(','):
+                        if fallback not in cats:
+                            cats.append(fallback)
+            if cats:
+                categories = ET.SubElement(root, 'categories')
+                for cat in cats:
+                    ET.SubElement(categories, 'category').text = cat
 
         # provides shared by all releases
         elements = {}

--- a/app/templates/category-details.html
+++ b/app/templates/category-details.html
@@ -1,0 +1,55 @@
+{% extends "default.html" %}
+{% block title %}Category Details{% endblock %}
+
+{% block content %}
+<h2>Category Details</h2>
+<form method="post" action="/lvfs/category/{{cat.category_id}}/modify">
+  <div class="form-group">
+    <label for="group_id">Value:</label>
+    <input type="text" class="form-control" name="value" value="{{cat.value}}" required {{'disabled' if not cat.check_acl('@modify')}}>
+  </div>
+  <div class="form-group">
+    <label for="display_name">Name:</label>
+    <input type="text" class="form-control" name="name" value="{{cat.name if cat.name}}" required {{'disabled' if not cat.check_acl('@modify')}}>
+  </div>
+  <div class="form-group">
+    <label for="display_name">Fallbacks:</label>
+    <input type="text" class="form-control" name="name" value="{{cat.fallbacks if cat.fallbacks}}" required {{'disabled' if not cat.check_acl('@modify')}}>
+  </div>
+{% if cat.check_acl('@modify') %}
+  <input type="submit" class="btn btn-primary btn-large" value="Modify">
+  <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#deleteModal">Delete</button>
+{% endif %}
+</form>
+
+<!-- modal dialog -->
+<div class="modal" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteModalLabel">Really Delete Category?</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Once deleted, categories can not be recovered.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <a class="btn btn-danger" href="/lvfs/category/{{cat.category_id}}/delete" role="button">Delete</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block breadcrumb %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb mt-3">
+    <li class="breadcrumb-item"><a href="{{url_for('.category_all')}}">Categories</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{cat.value}}</li>
+  </ol>
+</nav>
+{% endblock %}

--- a/app/templates/category-list.html
+++ b/app/templates/category-list.html
@@ -1,0 +1,50 @@
+{% extends "default.html" %}
+{% block title %}Categories{% endblock %}
+
+{% block content %}
+<h1>Update Categories</h1>
+
+{% if categories|length == 0 %}
+<p>
+  No categories have been created.
+</p>
+
+{% else %}
+
+<table class="table">
+  <tr class="row">
+    <th class="col-sm-5">Value</th>
+    <th class="col-sm-5">Name</th>
+    <th class="col-sm-2">&nbsp;</th>
+  </tr>
+{% for cat in categories %}
+  <tr class="row">
+    <td class="col-sm-5"><code>{{cat.value}}</code></td>
+    <td class="col-sm-5">{{cat.name}}</td>
+    <td class="col-sm-2">
+      <a class="btn btn-info btn-block"
+         href="/lvfs/category/{{cat.category_id}}/details"
+         role="button">Details &raquo;</a>
+    </td>
+  </tr>
+{% endfor %}
+</table>
+
+{% endif %}
+
+<hr/>
+
+<h2>Create a new update category</h2>
+<form method="post" action="/lvfs/category/add" class="form-inline">
+  <div class="table">
+    <div class="row">
+      <div class="col-sm-10">
+        <input class="form-control" type="text" size="100" name="value" placeholder="Value" required>
+      </div>
+      <div class="col-sm-2">
+        <input class="btn btn-primary btn-block" type="submit" value="Add">
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/component-overview.html
+++ b/app/templates/component-overview.html
@@ -11,7 +11,7 @@
   </tr>
   <tr class="row">
     <th class="col-sm-3">Name</th>
-    <td class="col-sm-9"><code>{{md.name}}</code></td>
+    <td class="col-sm-9"><code>{{md.name_with_category}}</code></td>
   </tr>
   <tr class="row">
     <th class="col-sm-3">Summary</th>
@@ -57,6 +57,23 @@
     </td>
 {% else %}
     <td class="col-sm-7"><code>{{md.protocol.value}}</code></td>
+{% endif %}
+  </tr>
+  <tr class="row">
+    <th class="col-sm-3">Category</th>
+{% if md.fw.remote.name != 'stable' or g.user.check_acl('@admin') %}
+    <td class="col-sm-7">
+      <select class="form-control" name="category_id">
+{% for cat in categories %}
+        <option value="{{cat.category_id}}" {{ 'selected' if md.category and md.category.value == cat.value }}>{{ cat.name if cat.name else cat.value}}</option>
+{% endfor %}
+      </select>
+    </td>
+    <td class="col-sm-2">
+      <input type="submit" class="btn btn-secondary btn-block" value="Set"/>
+    </td>
+{% else %}
+    <td class="col-sm-7"><code>{{md.category.value}}</code></td>
 {% endif %}
   </tr>
   </form>

--- a/app/templates/devicelist.html
+++ b/app/templates/devicelist.html
@@ -36,7 +36,7 @@
   <div class="card">
     <div class="card-body">
       <p class="card-text">
-        Support for the <a href="/lvfs/device/{{fw.md_prio.guids[0].value}}">{{fw.md_prio.name_display}}</a>
+        Support for the <a href="/lvfs/device/{{fw.md_prio.guids[0].value}}">{{fw.md_prio.name}}</a>
         was added by {{fw.md_prio.developer_name_display}}.
       </p>
     </div>
@@ -59,7 +59,7 @@
 <ul class="list-group">
 {% for md in mds_by_vendor[vendor] %}
   <li class="list-group-item">
-    <a href="/lvfs/device/{{md.guids[0].value}}">{{md.name}}</a>
+    <a href="/lvfs/device/{{md.guids[0].value}}">{{md.name_with_category}}</a>
   </li>
 {% endfor %}
 </ul>

--- a/app/templates/docs-metainfo-category.html
+++ b/app/templates/docs-metainfo-category.html
@@ -1,0 +1,43 @@
+{% extends "default.html" %}
+
+{% block title %}MetaInfo Files : Update Category{% endblock %}
+
+{% block content %}
+<h2>Update Category</h2>
+<p>
+  By telling the LVFS the firmware category to use for the component the front end can
+  correctly translate the update type in the UI.
+  Also for this reason, <code>.metainfo.xml</code> files <strong>should not</strong>
+  include the words <code>ME</code>, <code>EC</code>, <code>BIOS</code>, <code>Firmware</code>,
+  <code>Device</code> or <code>Update</code> in the component name and they will
+  be removed if included.
+</p>
+<p>
+  The component category can be set as part of the <code>metainfo.xml</code> file
+  or set from the LVFS web console.
+  Most users will want to include the extra metadata to make the upload process
+  quicker for QA engineers.
+  To do this, add this to the metainfo file:
+</p>
+<pre>
+  &lt;categories&gt;
+    &lt;category&gt;some-value-here&lt;/category&gt;
+  &lt;/categories&gt;
+</pre>
+<p>
+  Allowed values for <code>category</code> are currently:
+</p>
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col-sm-5">Value</th>
+    <th class="col-sm-5">Displayed Name</th>
+  </tr>
+{% for cat in categories %}
+  <tr class="row">
+    <td class="col-sm-5"><code>{{cat.value}}</code></td>
+    <td class="col-sm-5">{{cat.name}}</td>
+  </tr>
+{% endfor %}
+</table>
+
+{% endblock %}

--- a/app/templates/firmware-new.html
+++ b/app/templates/firmware-new.html
@@ -23,7 +23,7 @@
     <td class="col-sm-2">{{format_humanize_naturaltime(fwev.timestamp)}}</td>
     <td class="col-sm-5">
       {{fwev.fw.md_prio.developer_name_display}}
-      {{fwev.fw.md_prio.name_display}}
+      {{fwev.fw.md_prio.name}}
     </td>
     <td class="col-sm-3">{{fwev.fw.version_display}}</td>
     <td class="col-sm-2">

--- a/app/templates/firmware-problems.html
+++ b/app/templates/firmware-problems.html
@@ -55,6 +55,18 @@
         <code>&lt;custom&gt;<br/>&nbsp;&nbsp;&lt;value key="LVFS::UpdateProtocol"&gt;org.uefi.capsule&lt;/value&gt;<br/>&lt;/custom&gt;</code>
       </p>
     </td>
+{% elif problem.kind == 'no-category' %}
+    <td class="col-sm-7">
+      <p class="card-text">
+        All components should have a defined update category before being moved
+        to stable.
+      </p>
+      <p class="card-text">
+        For future firmware uploads, this can be set automatically using this
+        in the <a href="/metainfo"><code>.metainfo.xml</code></a> file:<br/>
+        <code>&lt;categories&gt;<br/>&nbsp;&nbsp;&lt;category&gt;X-Device&lt;/category&gt;<br/>&lt;/categories&gt;</code>
+      </p>
+    </td>
 {% elif problem.kind == 'invalid-release-description' %}
     <td class="col-sm-7">
       <p class="card-text">

--- a/app/templates/private.html
+++ b/app/templates/private.html
@@ -61,6 +61,7 @@
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="/lvfs/settings">Server Settings</a>
           <a class="dropdown-item" href="{{url_for('.protocol_all')}}">Flashing Protocols</a>
+          <a class="dropdown-item" href="{{url_for('.category_all')}}">Update Categories</a>
           <a class="dropdown-item" href="{{url_for('.agreement_list')}}">Agreements</a>
         </div>
       </li>
@@ -112,6 +113,7 @@
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='restrict')}}">Adding Restrictions</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='protocol')}}">Update Protocol</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='version')}}">Version Format</a>
+          <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='category')}}">Update Category</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='urls')}}">Source URLs</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='style')}}">Style Guide</a>
           <a class="dropdown-item" href="{{url_for('.docs_composite')}}">Composite Devices</a>

--- a/app/templates/public.html
+++ b/app/templates/public.html
@@ -34,6 +34,7 @@
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='restrict')}}">Adding Restrictions</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='protocol')}}">Update Protocol</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='version')}}">Version Format</a>
+          <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='category')}}">Update Category</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='urls')}}">Source URLs</a>
           <a class="dropdown-item" href="{{url_for('.docs_metainfo', page='style')}}">Style Guide</a>
           <a class="dropdown-item" href="{{url_for('.docs_composite')}}">Composite Devices</a>

--- a/app/util.py
+++ b/app/util.py
@@ -25,6 +25,18 @@ gi.require_version('GCab', '1.0')
 from gi.repository import GCab
 from gi.repository import GLib
 
+def _fix_component_name(name, developer_name=None):
+    if not name:
+        return None
+    words_new = []
+    words_banned = ['firmware', 'update', 'system', 'device', 'bios', 'me', 'controller']
+    if developer_name:
+        words_banned.append(developer_name.lower())
+    for word in name.split(' '):
+        if word.lower() not in words_banned:
+            words_new.append(word)
+    return ' '.join(words_new)
+
 def _unwrap_xml_text(txt):
     txt = txt.replace('\r', '')
     new_lines = []

--- a/app/views.py
+++ b/app/views.py
@@ -26,7 +26,7 @@ from app import app, db, lm, ploader
 from .dbutils import _execute_count_star
 from .pluginloader import PluginError
 
-from .models import Firmware, Requirement, Component, Vendor, Protocol
+from .models import Firmware, Requirement, Component, Vendor, Protocol, Category
 from .models import User, Analytic, Client, Event, Useragent, AnalyticVendor
 from .models import _get_datestr_from_datetime
 from .hash import _addr_hash
@@ -267,11 +267,13 @@ def docs_vendors():
 @app.route('/lvfs/docs/metainfo')
 @app.route('/lvfs/docs/metainfo/<page>')
 def docs_metainfo(page='intro'):
-    if page not in ['intro', 'style', 'restrict', 'protocol', 'version', 'urls']:
+    if page not in ['intro', 'style', 'restrict', 'protocol', 'version', 'urls', 'category']:
         return _error_internal('No metainfo page name %s' % page)
     protocols = db.session.query(Protocol).order_by(Protocol.protocol_id.asc()).all()
+    categories = db.session.query(Category).order_by(Category.category_id.asc()).all()
     return render_template('docs-metainfo-%s.html' % page,
                            protocols=protocols,
+                           categories=categories,
                            page=page)
 
 @app.route('/lvfs/docs/composite')

--- a/app/views_category.py
+++ b/app/views_category.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+
+from flask import request, url_for, redirect, flash, g, render_template
+from flask_login import login_required
+
+from app import app, db
+
+from .models import Category
+from .util import _error_internal, _error_permission_denied
+
+@app.route('/lvfs/category/all')
+@login_required
+def category_all():
+
+    # security check
+    if not g.user.check_acl('@view-categories'):
+        return _error_permission_denied('Unable to view categories')
+
+    # only show categories with the correct group_id
+    categories = db.session.query(Category).order_by(Category.category_id.asc()).all()
+    return render_template('category-list.html', categories=categories)
+
+@app.route('/lvfs/category/add', methods=['POST'])
+@login_required
+def category_add():
+
+    # security check
+    if not Category('').check_acl('@create'):
+        return _error_permission_denied('Unable to add category')
+
+    # ensure has enough data
+    if 'value' not in request.form:
+        return _error_internal('No form data found!')
+    value = request.form['value']
+    if not value or not value.startswith('X-') or value.find(' ') != -1:
+        flash('Failed to add category: Value needs to be a valid group name', 'warning')
+        return redirect(url_for('.category_all'))
+
+    # already exists
+    if db.session.query(Category).filter(Category.value == value).first():
+        flash('Failed to add category: The category already exists', 'info')
+        return redirect(url_for('.category_all'))
+
+    # add category
+    cat = Category(value=request.form['value'])
+    db.session.add(cat)
+    db.session.commit()
+    flash('Added category', 'info')
+    return redirect(url_for('.category_details', category_id=cat.category_id))
+
+@app.route('/lvfs/category/<int:category_id>/delete')
+@login_required
+def category_delete(category_id):
+
+    # get category
+    cat = db.session.query(Category).\
+            filter(Category.category_id == category_id).first()
+    if not cat:
+        flash('No category found', 'info')
+        return redirect(url_for('.category_all'))
+
+    # security check
+    if not cat.check_acl('@modify'):
+        return _error_permission_denied('Unable to delete category')
+
+    # delete
+    db.session.delete(cat)
+    db.session.commit()
+    flash('Deleted category', 'info')
+    return redirect(url_for('.category_all'))
+
+@app.route('/lvfs/category/<int:category_id>/modify', methods=['POST'])
+@login_required
+def category_modify(category_id):
+
+    # find category
+    cat = db.session.query(Category).\
+                filter(Category.category_id == category_id).first()
+    if not cat:
+        flash('No category found', 'info')
+        return redirect(url_for('.category_all'))
+
+    # security check
+    if not cat.check_acl('@modify'):
+        return _error_permission_denied('Unable to modify category')
+
+    # modify category
+    for key in ['name', 'fallbacks']:
+        if key in request.form:
+            setattr(cat, key, request.form[key])
+    db.session.commit()
+
+    # success
+    flash('Modified category', 'info')
+    return redirect(url_for('.category_details', category_id=category_id))
+
+@app.route('/lvfs/category/<int:category_id>/details')
+@login_required
+def category_details(category_id):
+
+    # find category
+    cat = db.session.query(Category).\
+            filter(Category.category_id == category_id).first()
+    if not cat:
+        flash('No category found', 'info')
+        return redirect(url_for('.category_all'))
+
+    # security check
+    if not cat.check_acl('@view'):
+        return _error_permission_denied('Unable to view category details')
+
+    # show details
+    return render_template('category-details.html', cat=cat)

--- a/app/views_component.py
+++ b/app/views_component.py
@@ -11,7 +11,7 @@ from sqlalchemy import func
 
 from app import app, db, ploader
 
-from .models import Requirement, Component, Keyword, Checksum
+from .models import Requirement, Component, Keyword, Checksum, Category
 from .models import Protocol, Report, ReportAttribute
 from .util import _error_internal, _error_permission_denied
 from .hash import _is_sha1, _is_sha256
@@ -78,6 +78,8 @@ def firmware_component_modify(component_id):
         md.screenshot_url = request.form['screenshot_url']
     if 'protocol_id' in request.form:
         md.protocol_id = request.form['protocol_id']
+    if 'category_id' in request.form:
+        md.category_id = request.form['category_id']
     if 'screenshot_caption' in request.form:
         md.screenshot_caption = _sanitize_markdown_text(request.form['screenshot_caption'])
     if 'install_duration' in request.form:
@@ -165,8 +167,9 @@ def firmware_component_show(component_id, page='overview'):
         page = 'requires-advanced'
 
     protocols = db.session.query(Protocol).order_by(Protocol.protocol_id.asc()).all()
+    categories = db.session.query(Category).order_by(Category.category_id.asc()).all()
     return render_template('component-' + page + '.html',
-                           protocols=protocols, md=md, page=page)
+                           protocols=protocols, categories=categories, md=md, page=page)
 
 @app.route('/lvfs/component/<int:component_id>/requirement/delete/<requirement_id>')
 @login_required

--- a/app/views_upload.py
+++ b/app/views_upload.py
@@ -20,9 +20,9 @@ from flask_login import login_required
 from app import app, db, ploader
 
 from .models import Firmware, Component, Requirement, Guid, FirmwareEvent
-from .models import Vendor, Remote, Agreement, Affiliation, Checksum, Protocol
+from .models import Vendor, Remote, Agreement, Affiliation, Checksum, Protocol, Category
 from .uploadedfile import UploadedFile, FileTooLarge, FileTooSmall, FileNotSupported, MetadataInvalid
-from .util import _get_client_address, _get_settings, _markdown_from_xml
+from .util import _get_client_address, _get_settings, _markdown_from_xml, _fix_component_name
 from .util import _error_internal, _error_permission_denied
 from .util import _json_success, _json_error
 from .views_firmware import _firmware_delete
@@ -170,6 +170,16 @@ def _create_fw_from_uploaded_file(ufile):
                     filter(Protocol.value == metadata['LVFS::UpdateProtocol']).first()
             if pr:
                 md.protocol_id = pr.protocol_id
+
+        # allows OEM to specify category
+        for category in component.get_categories():
+            cat = db.session.query(Category).filter(Category.value == category).first()
+            if cat:
+                md.category_id = cat.category_id
+                break
+        # fallback to device -- DROP THIS 2020-01-01
+        if not md.category_id:
+            md.category_id = db.session.query(Category).filter(Category.value == 'X-Device').first().category_id
 
         # allows OEM to set banned country codes
         if 'LVFS::BannedCountryCodes' in metadata:
@@ -367,6 +377,13 @@ def upload():
     fw.remote_id = remote.remote_id
     fw.checksum_signed = hashlib.sha1(cab_data).hexdigest()
     fw.is_dirty = True
+
+    # fix name
+    for md in fw.mds:
+        name_fixed = _fix_component_name(md.name, md.developer_name_display)
+        if name_fixed != md.name:
+            flash('Fixed component name from "%s" to "%s"' % (md.name, name_fixed), 'warning')
+            md.name = name_fixed
 
     # fall back to a version format when unspecified and not semver
     for md in fw.mds:

--- a/lvfs_test.py
+++ b/lvfs_test.py
@@ -72,6 +72,10 @@ class LvfsTestCase(unittest.TestCase):
             value='com.hughski.colorhug',
         ), follow_redirects=True)
         assert b'Added protocol' in rv.data, rv.data
+        rv = self.app.post('/lvfs/category/add', data=dict(
+            value='X-Device',
+        ), follow_redirects=True)
+        assert b'Added category' in rv.data, rv.data
         rv = self.app.post('/lvfs/settings/modify', data=dict(
             clamav_enable='disabled',
         ), follow_redirects=True)
@@ -664,7 +668,7 @@ class LvfsTestCase(unittest.TestCase):
         # ensure user can still view firmware
         self.login('alice@acme.com', accept_agreement=False)
         rv = self.app.get('/lvfs/firmware')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
 
     def test_users(self):
 
@@ -992,7 +996,7 @@ ma+I7fM5pmgsEL4tkCZAg0+CPTyhHkMV/cWuOZUjqTsYbDq1pZI=
 
         # check the report appeared on the telemetry page
         rv = self.app.get('/lvfs/telemetry')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
         assert b'>1<' in rv.data, rv.data
 
         # delete the report
@@ -1261,7 +1265,7 @@ ma+I7fM5pmgsEL4tkCZAg0+CPTyhHkMV/cWuOZUjqTsYbDq1pZI=
         rv = self.app.get('/lvfs/firmware/1')
         assert '/downloads/' + self.checksum_upload in rv.data.decode('utf-8'), rv.data
         rv = self.app.get('/lvfs/firmware')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
 
         # check bob can change the update description and severity
         rv = self.app.post('/lvfs/component/1/modify', data=dict(
@@ -1403,15 +1407,15 @@ ma+I7fM5pmgsEL4tkCZAg0+CPTyhHkMV/cWuOZUjqTsYbDq1pZI=
 
         # search for one defined keyword
         rv = self.app.get('/lvfs/search?value=Alice')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
 
         # search for one defined keyword, again
         rv = self.app.get('/lvfs/search?value=Alice')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
 
         # search for a keyword and a name match
         rv = self.app.get('/lvfs/search?value=Alice+Edward+ColorHug2')
-        assert b'ColorHug2 Device Update' in rv.data, rv.data
+        assert b'ColorHug2' in rv.data, rv.data
 
     def test_anon_search_not_promoted(self):
 

--- a/migrations/versions/b59b7d74ed0f_add_component_category.py
+++ b/migrations/versions/b59b7d74ed0f_add_component_category.py
@@ -1,0 +1,97 @@
+"""
+
+Revision ID: b59b7d74ed0f
+Revises: b73c19797ab0
+Create Date: 2019-03-28 22:20:34.726745
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b59b7d74ed0f'
+down_revision = '65b618b6e525'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from app import db
+from app.models import Component, Category
+from app.util import _fix_component_name
+
+def upgrade():
+
+    if 1:
+        op.create_table('categories',
+        sa.Column('category_id', sa.Integer(), nullable=False),
+        sa.Column('value', sa.Text(), nullable=False),
+        sa.Column('name', sa.Text(), nullable=True),
+        sa.Column('fallbacks', sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint('category_id'),
+        sa.UniqueConstraint('category_id'),
+        mysql_character_set='utf8mb4'
+        )
+        op.add_column('components', sa.Column('category_id', sa.Integer(), nullable=True))
+        op.create_foreign_key('components_ibfk_3', 'components', 'categories', ['category_id'], ['category_id'])
+        db.session.commit()
+
+    if 1:
+        #db.session.add(Category(value='', name='Unknown'))
+        db.session.add(Category(value='X-System', name='System Update'))
+        db.session.add(Category(value='X-Device', name='Device Update'))
+        db.session.add(Category(value='X-EmbeddedController', name='Embedded Controller Update'))
+        db.session.add(Category(value='X-ManagementEngine', name='Management Engine Update'))
+        db.session.add(Category(value='X-Controller', name='Controller Update'))
+        db.session.commit()
+
+    # convert the existing components
+    apxs = {}
+    for cat in db.session.query(Category).all():
+        apxs[cat.value] = cat
+    for md in db.session.query(Component).all():
+
+        # already set
+        if md.category_id:
+            continue
+
+        # find suffix
+        for apx_value in apxs:
+            cat = apxs[apx_value]
+            for suffix in ['System Update', 'System Firmware', 'BIOS']:
+                if md.name.endswith(suffix) or md.summary.endswith(suffix):
+                    md.category_id = apxs['X-System'].category_id
+                    break
+            for suffix in ['Embedded Controller', 'Embedded controller']:
+                if md.name.endswith(suffix) or md.summary.endswith(suffix):
+                    md.category_id = apxs['X-System'].category_id
+                    break
+            for suffix in ['ME Firmware']:
+                if md.name.endswith(suffix) or md.summary.endswith(suffix):
+                    md.category_id = apxs['X-ManagementEngine'].category_id
+                    break
+            for suffix in ['controller Update']:
+                if md.name.endswith(suffix) or md.summary.endswith(suffix):
+                    md.category_id = apxs['controller'].category_id
+                    break
+
+        # protocol fallback
+        if not md.category_id:
+            if md.protocol and md.protocol.value in ['org.flashrom', 'org.uefi.capsule', 'org.uefi.capsule']:
+                md.category_id = apxs['X-System'].category_id
+            else:
+                md.category_id = apxs['X-Device'].category_id
+
+        # fix component name
+        name_new = _fix_component_name(md.name, md.developer_name_display)
+        if md.name != name_new:
+            print('Fixing %s->%s' % (md.name, name_new))
+            md.name = name_new
+        else:
+            print('Ignoring %s' % md.name)
+
+    # all done
+    db.session.commit()
+
+def downgrade():
+    op.drop_constraint('components_ibfk_3', 'components', type_='foreignkey')
+    op.drop_column('components', 'category_id')
+    op.drop_table('categories')


### PR DESCRIPTION
Some firmwares only update one part of the system, e.g. the EC or ME firmware.
Other updates include all the updates needed for the whole system, and vendors
have been doing different things with the component name due to this.

Some examples of the brokenness:

* `Logitech Unifying Receiver` -> `Logitech Logitech Unifying Receiver`
* `Thunderbolt Firmware Update for AKiTiO Node Lite` -> `AKiTiO Thunderbolt Firmware Update for AKiTiO Node Lite`
* `Star LabTop Mk III Embedded Controller Firmware` -> `Star Labs Star LabTop Mk III Embedded Controller Firmware`
* `ChengMing 3967 System Update`
* `Thunderbolt Firmware Update for 0x07E6, XPS9370`
* `Z440/Z640/Z840 Workstation System BIOS`

The translator teams are also frustrated that they cannot translate terms like
`System Update` and also provide the correct versions of `Device`.

To fix, add an enumerated set of firmware 'styles' that can be set by the
uploader in the metainfo.xml file (or changed the LVFS) which automatically
set the name suffix.

On firmware upload, remove any of the words we're going to suffix and provide
a nag warning to the uploader only. For existing firmware convert them to having
the correct scope and fix the names used in the AppStream metadata.

In the future we can set the LVFS:UpdateStyle entry in the metadata and provide
translations in the frontend. This obviously needs changes to fwupd and more
importantly gnome-software and the KDE software center so gently phase this in.