### PR TITLE
Do not use a nav header for settings

### DIFF
--- a/app/templates/private.html
+++ b/app/templates/private.html
@@ -130,9 +130,6 @@
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'user_list'}}">
               <a class="nav-link" href="{{url_for('.user_list')}}">User List</a>
             </li>
-            <li class="nav-item {{'active' if request.url_rule.endpoint == 'settings_view'}}">
-              <a class="nav-link" href="{{url_for('.settings_view')}}">Server Settings</a>
-            </li>
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'protocol_all'}}">
               <a class="nav-link" href="{{url_for('.protocol_all')}}">Flashing Protocols</a>
             </li>
@@ -142,6 +139,23 @@
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'agreement_list'}}">
               <a class="nav-link" href="{{url_for('.agreement_list')}}">Agreements</a>
             </li>
+          </ul>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link dropdown-indicator" href="#settings" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="settings">
+            <div class="d-flex align-items-center">
+              <span class="nav-link-icon">
+                <span class="fas fa-cogs"></span>
+              </span>
+              <span>Settings</span>
+            </div>
+          </a>
+          <ul class="nav collapse {{'show' if category == 'settings'}}" id="settings" data-parent="#navbarVerticalCollapse">
+{% for plugin in loader_plugins %}
+            <li class="nav-item {{'active' if request.url_rule.endpoint == 'settings_view' and plugin_id == plugin.id}}">
+              <a class="nav-link" href="{{url_for('.settings_view', plugin_id=plugin.id)}}">{{plugin.name()}}</a>
+            </li>
+{% endfor %}
           </ul>
         </li>
         <li class="nav-item">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,25 +1,12 @@
 {% extends "default.html" %}
 {% block title %}Settings{% endblock %}
 
-{% block nav %}
-<nav>
-  <div class="text-center mb-3">
-    <div class="btn-group" role="group">
-{% for plugin in plugins %}
-      <a class="btn btn-falcon-{{'primary' if plugin_id == plugin.id else 'default'}}"
-        href="{{url_for('.settings_view', plugin_id=plugin.id)}}">{{plugin.name()}}</a>
-{% endfor %}
-    </div>
-  </div>
-</nav>
-{% endblock %}
-
 {% block content %}
 <div class="card">
   <div class="card-body">
   <form class="form" method="post" action="{{url_for('.settings_modify', plugin_id=plugin_id)}}">
 
-{% for plugin in plugins %}
+{% for plugin in loader_plugins %}
 {% if plugin.id == plugin_id %}
     <div class="card-title">{{plugin.name()}}</div>
     <p class="card-text">{{plugin.summary()}}</p>

--- a/app/views.py
+++ b/app/views.py
@@ -199,7 +199,8 @@ def utility_processor():
                 format_humanize_intchar=format_humanize_intchar,
                 format_timedelta_approx=format_timedelta_approx,
                 format_html_from_markdown=format_html_from_markdown,
-                format_timestamp=format_timestamp)
+                format_timestamp=format_timestamp,
+                loader_plugins=ploader.get_all())
 
 @lm.unauthorized_handler
 def unauthorized():

--- a/app/views_settings.py
+++ b/app/views_settings.py
@@ -23,9 +23,8 @@ def settings_view(plugin_id='general'):
     if not g.user.check_acl('@admin'):
         return _error_permission_denied('Only admin is allowed to change settings')
     return render_template('settings.html',
-                           category='admin',
+                           category='settings',
                            settings=_get_settings(),
-                           plugins=ploader.get_all(),
                            plugin_id=plugin_id)
 
 @app.route('/lvfs/settings_create')

--- a/plugins/auth-azure/__init__.py
+++ b/plugins/auth-azure/__init__.py
@@ -38,7 +38,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'Azure'
+        return 'Azure AD'
 
     def summary(self):
         return 'Authenticate against Microsoft Azure Active Directory.'

--- a/plugins/sign-gpg/__init__.py
+++ b/plugins/sign-gpg/__init__.py
@@ -65,7 +65,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'GPG'
+        return 'GPG Signing'
 
     def summary(self):
         return 'Sign files using GnuPG, a free implementation of the OpenPGP standard.'

--- a/plugins/sign-pkcs7/__init__.py
+++ b/plugins/sign-pkcs7/__init__.py
@@ -18,7 +18,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'PKCS#7'
+        return 'PKCS#7 Signing'
 
     def summary(self):
         return 'Sign files using the GnuTLS public key infrastructure.'

--- a/plugins/sign-sigul/__init__.py
+++ b/plugins/sign-sigul/__init__.py
@@ -52,7 +52,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'Sigul'
+        return 'Sigul Signing'
 
     def summary(self):
         return 'GPG sign files using Sigul, a secure signing server.'

--- a/plugins/virustotal/__init__.py
+++ b/plugins/virustotal/__init__.py
@@ -17,7 +17,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'VirusTotal'
+        return 'VirusTotal Monitor'
 
     def summary(self):
         return 'Upload firmware to VirusTotal for false-positive detection'

--- a/plugins/wu-copy/__init__.py
+++ b/plugins/wu-copy/__init__.py
@@ -14,7 +14,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self)
 
     def name(self):
-        return 'WU'
+        return 'Windows Update'
 
     def summary(self):
         return 'Copy files generated using Windows Update.'


### PR DESCRIPTION
The number of plugins is too many to display as a nav. Promote the settings
view to a top level in the private menu.

This also allows us to use sensible names for the plugins.