### PR TITLE
Use CHIPSEC to add component shards for UEFI firmware

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,3 +101,4 @@ from app import views_agreement
 from app import views_protocol
 from app import views_category
 from app import views_test
+from app import views_shard

--- a/app/templates/component-nav.html
+++ b/app/templates/component-nav.html
@@ -11,14 +11,18 @@
         href="{{url_for('.component_show', component_id=md.component_id, page='overview')}}">Overview</a>
 {% if md.protocol and md.protocol.can_verify %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'component_checksums' else 'default'}}"
-        href="{{url_for('.component_checksums', component_id=md.component_id)}}">Device Checksums</a>
+        href="{{url_for('.component_checksums', component_id=md.component_id)}}">Checksums</a>
 {% endif %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'component_show' and page == 'update' else 'default'}}"
-        href="{{url_for('.component_show', component_id=md.component_id, page='update')}}">Update Details</a>
+        href="{{url_for('.component_show', component_id=md.component_id, page='update')}}">Update</a>
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'component_show' and page in ['requires', 'requires-advanced'] else 'default'}}"
         href="{{url_for('.component_show', component_id=md.component_id, page='requires')}}">Requirements</a>
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'component_show' and page == 'keywords' else 'default'}}"
-        href="{{url_for('.component_show', component_id=md.component_id, page='keywords')}}">Search Keywords</a>
+        href="{{url_for('.component_show', component_id=md.component_id, page='keywords')}}">Keywords</a>
+{% if md.shards %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'component_shards' else 'default'}}"
+        href="{{url_for('.component_shards', component_id=md.component_id)}}">Shards</a>
+{% endif %}
     </div>
   </div>
 </nav>

--- a/app/templates/component-overview.html
+++ b/app/templates/component-overview.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 <div class="card">
+  <div class="bg-holder bg-card" style="background-image:url(/img/corner-1.png);"></div>
   <div class="card-body">
 <table class="table">
   <tr class="row table-borderless">
@@ -135,9 +136,17 @@
   </tr>
   </form>
 {% endif %}
-  <tr class="row">
-    <th class="col-3">Security</th>
-    <td class="col">
+</table>
+  </div>
+</div>
+
+<div class="card mt-3">
+  <div class="bg-holder bg-card" style="background-image:url(/img/corner-2.png);"></div>
+  <div class="card-body">
+    <div class="card-title">
+      Security
+    </div>
+    <div class="card-text">
       <ul class="list-group">
 {% for attr in md.security_claim.attrs|sort() %}
         <li class="list-group-item">
@@ -150,9 +159,8 @@
         </li>
 {% endfor %}
       </ul>
-    </td>
-  </tr>
-</table>
+    </div>
   </div>
 </div>
+
 {% endblock %}

--- a/app/templates/component-shards.html
+++ b/app/templates/component-shards.html
@@ -1,0 +1,33 @@
+{% extends "default.html" %}
+{% block title %}Device Shards{% endblock %}
+
+{% block nav %}{% include 'component-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% for shard in md.shards %}
+<div class="card mb-3">
+  <div class="card-body">
+    <div class="card-title">
+      {{shard.info.name}}
+      <code class="float-right small">{{shard.info.guid}}</code>
+    </div>
+    <p class="card-text">
+{% if shard.info.description %}
+      {{shard.info.description}}
+{% else %}
+      We don't know what this module does! Can you tell us?
+{% endif %}
+    </p>
+{% for csum in shard.checksums %}
+    <p class="card-text">
+      <code>{{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+    <a class="card-link btn btn-info" href="{{url_for('.firmware_shard_search', kind='checksum', value=shard.checksum)}}">Search checksum</a>
+    <a class="card-link btn btn-info" href="{{url_for('.firmware_shard_search', kind='guid', value=shard.info.guid)}}">Search GUID</a>
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/app/templates/device-shards-diff.html
+++ b/app/templates/device-shards-diff.html
@@ -1,0 +1,76 @@
+{% extends "default.html" %}
+{% block title %}{{md_old.name}} {{md_old.version_display}} -> {{md_new.version_display}} {% endblock %}
+
+{% block nav %}{% include 'device-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% for shard in shards_added %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-danger">
+    {{shard.info.name}} : Added
+    <code class="float-right">{{shard.info.guid}}</code>
+  </div>
+  <div class="card-body">
+{% if shard.info.description_with_fallback %}
+    <p class="card-text">
+      {{shard.info.description_with_fallback}}
+    </p>
+{% endif %}
+{% for csum in shard.checksums %}
+    <p class="card-text">
+      <code>{{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+  </div>
+</div>
+{% endfor %}
+
+{% for shard in shards_removed %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-success">
+    {{shard.info.name}} : Removed
+    <code class="float-right">{{shard.info.guid}}</code>
+  </div>
+  <div class="card-body">
+{% if shard.info.description_with_fallback %}
+    <p class="card-text">
+      {{shard.info.description_with_fallback}}
+    </p>
+{% endif %}
+{% for csum in shard.checksums %}
+    <p class="card-text">
+      <code>{{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+  </div>
+</div>
+{% endfor %}
+
+{% for shard_new, shard_old in shards_changed %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-warning">
+    {{shard_new.info.name}} : Changed
+    <code class="float-right">{{shard_new.guid}}</code>
+  </div>
+  <div class="card-body">
+{% if shard_new.info.description_with_fallback %}
+    <p class="card-text">
+      {{shard_new.info.description_with_fallback}}
+    </p>
+{% endif %}
+{% for csum in shard_old.checksums %}
+    <p class="card-text">
+      <code>Old {{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+{% for csum in shard_new.checksums %}
+    <p class="card-text">
+      <code>New {{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/app/templates/device-shards.html
+++ b/app/templates/device-shards.html
@@ -1,0 +1,29 @@
+{% extends "default.html" %}
+{% block title %}{{md.name}}{% endblock %}
+
+{% block nav %}{% include 'device-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% for shard in md.shards %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-info">
+    {{shard.info.name}}
+    <code class="float-right">{{shard.info.guid}}</code>
+  </div>
+  <div class="card-body">
+{% if shard.info.description_with_fallback %}
+    <p class="card-text">
+      {{shard.info.description_with_fallback}}
+    </p>
+{% endif %}
+{% for csum in shard.checksums %}
+    <p class="card-text">
+      <code>{{csum.kind}}: {{csum.value}}</code>
+    </p>
+{% endfor %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/app/templates/device.html
+++ b/app/templates/device.html
@@ -114,6 +114,14 @@
     </div>
   </div>
 </div>
+{% if fw.md_prio.shards %}
+    <a class="card-link btn btn-info" href="{{url_for('.device_shards', component_id=fw.md_prio.component_id)}}">Firmware Details</a>
+{% if fw_previous[fw] %}
+    <a class="card-link btn btn-info" href="{{url_for('.device_shards_diff',
+                                                      component_id_old=fw_previous[fw].md_prio.component_id,
+                                                      component_id_new=fw.md_prio.component_id)}}">Compare with previous</a>
+{% endif %}
+{% endif %}
   </div>
 </div>
 {% endif %}

--- a/app/templates/device.html
+++ b/app/templates/device.html
@@ -37,7 +37,6 @@
 </div>
 
 {% for fw in fws %}
-{% if (g.user is defined and g.user.check_acl('@admin')) or fw.remote.is_public %}
 <div class="card mt-3">
   <div class="card-body">
   <div class="card-title">Version {{fw.version_display}}:</div>
@@ -124,7 +123,6 @@
 {% endif %}
   </div>
 </div>
-{% endif %}
 {% endfor %}
 
 {% endif %}

--- a/app/templates/docs-news.html
+++ b/app/templates/docs-news.html
@@ -9,6 +9,34 @@
 
 -->
 
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-info">
+    <div class="row">
+      <div class="col col-lg-8 text-truncate">LVFS Version 1.1.0 Released</div>
+      <div class="col">
+        <span class="float-right">2019-05-14</span>
+      </div>
+    </div>
+  </div>
+  <div class="card-body">
+    <p class="card-text">
+      This release adds the following features:
+    </p>
+    <ul>
+      <li>Run CHIPSEC on all UEFI firmware files</li>
+      <li>Show details of UEFI firmware volumes for capsule updates</li>
+      <li>Show differences between public revisions of firmware</li>
+      <li>Provide some extra information about detected firmware shards</li>
+    </ul>
+    <p class="card-text">This release fixes the following bugs:</p>
+    <ul>
+      <li>Only decompress the firmware once when running tests</li>
+      <li>Make the component detail page a bit less monolithic</li>
+      <li>Never leave tests in the running state if a plugin crashes</li>
+    </ul>
+  </div>
+</div>
+
 <div class="card">
   <div class="card-header card-title list-group-item-info">
     <div class="row">

--- a/app/templates/private.html
+++ b/app/templates/private.html
@@ -39,14 +39,14 @@
               <a class="nav-link" href="{{url_for('.vendor_users', vendor_id=g.user.vendor_id)}}">Vendor</a>
             </li>
 {% endif %}
+            <li class="nav-item {{'active' if request.url_rule.endpoint == 'docs_news'}}">
+              <a class="nav-link" href="{{url_for('.docs_news')}}">News</a>
+            </li>
 {% if g.user.check_acl('@view-eventlog') %}
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'eventlog'}}">
               <a class="nav-link" href="{{url_for('.eventlog')}}">Events</a>
             </li>
 {% endif %}
-            <li class="nav-item {{'active' if request.url_rule.endpoint == 'docs_news'}}">
-              <a class="nav-link" href="{{url_for('.docs_news')}}">LVFS News</a>
-            </li>
           </ul>
         </li>
         <li class="nav-item">
@@ -135,6 +135,9 @@
             </li>
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'category_all'}}">
               <a class="nav-link" href="{{url_for('.category_all')}}">Update Categories</a>
+            </li>
+            <li class="nav-item {{'active' if request.url_rule.endpoint == 'shard_all'}}">
+              <a class="nav-link" href="{{url_for('.shard_all')}}">Component Shards</a>
             </li>
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'agreement_list'}}">
               <a class="nav-link" href="{{url_for('.agreement_list')}}">Agreements</a>
@@ -374,7 +377,7 @@
     <footer>
       <div class="row no-gutters justify-content-between fs--1 mt-4 mb-3">
         <div class="col-12 col-sm-auto">
-          <p class="mb-0">LVFS version 1.0.0 &mdash; By <a class="text-700" href="mailto:richard@hughsie.com">Richard Hughes</a> &copy; 2015-2019</p>
+          <p class="mb-0">LVFS version 1.1.0 &mdash; By <a class="text-700" href="mailto:richard@hughsie.com">Richard Hughes</a> &copy; 2015-2019</p>
           <p class="mb-0">Linux Vendor Firmware Service Project a Series of LF Projects, LLC</p>
         </div>
       </div>

--- a/app/templates/shard-details.html
+++ b/app/templates/shard-details.html
@@ -1,0 +1,24 @@
+{% extends "default.html" %}
+{% block title %}Component Shard Details{% endblock %}
+
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <div class="card-title">Component Shard Details</div>
+<form method="post" action="{{url_for('.shard_modify', component_shard_info_id=shard.component_shard_info_id)}}">
+  <div class="form-group">
+    <label for="display_name">Name:</label>
+    <input type="text" class="form-control" name="name" value="{{shard.name if shard.name}}" required {{'disabled' if not shard.check_acl('@modify')}}>
+  </div>
+  <div class="form-group">
+    <label for="display_name">Description:</label>
+    <textarea type="text" class="form-control" name="description" rows="10" {{'disabled' if not shard.check_acl('@modify')}}>{{shard.description if shard.description}}</textarea>
+  </div>
+{% if shard.check_acl('@modify') %}
+  <input type="submit" class="btn btn-primary btn-large" value="Modify">
+{% endif %}
+</form>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/shard-list.html
+++ b/app/templates/shard-list.html
@@ -1,0 +1,40 @@
+{% extends "default.html" %}
+{% block title %}Component Shards{% endblock %}
+
+{% block content %}
+
+{% if shards|length == 0 %}
+<div class="card">
+  <div class="card-body">
+    <p class="card-text">
+      No shards have been created.
+    </p>
+  </div>
+</div>
+
+{% else %}
+
+{% for shard in shards %}
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">
+      {{shard.name}} ({{shard.cnt}})
+      <code class="float-right">{{shard.guid}}</code>
+    </div>
+    <div class="card-text mb-3">
+{% if shard.description %}
+      {{shard.description}}
+{% else %}
+      No description!
+{% endif %}
+    </div>
+    <a class="card-link btn btn-info"
+      href="{{url_for('.shard_details', component_shard_info_id=shard.component_shard_info_id)}}"
+      role="button">Details &raquo;</a>
+  </div>
+</div>
+{% endfor %}
+
+{% endif %}
+
+{% endblock %}

--- a/app/views_component.py
+++ b/app/views_component.py
@@ -43,6 +43,29 @@ def component_problems():
                            category='firmware',
                            mds=mds)
 
+@app.route('/lvfs/component/<int:component_id>/shards')
+@login_required
+def component_shards(component_id):
+    """
+    Show the shards of each component
+    """
+
+    # get firmware component
+    md = db.session.query(Component).filter(Component.component_id == component_id).first()
+    if not md:
+        return _error_internal('No component matched!')
+
+    # security check
+    fw = md.fw
+    if not fw:
+        return _error_internal('No firmware matched!')
+    if not fw.check_acl('@view'):
+        return _error_permission_denied('Unable to view component')
+
+    return render_template('component-shards.html',
+                           category='firmware',
+                           md=md, page='shards')
+
 @app.route('/lvfs/component/<int:component_id>/modify', methods=['POST'])
 @login_required
 def component_modify(component_id):

--- a/app/views_device.py
+++ b/app/views_device.py
@@ -51,11 +51,13 @@ def _get_fws_for_appstream_id(value):
     # old, deprecated GUID view
     if len(value.split('-')) == 5:
         return db.session.query(Firmware).\
+                    join(Remote).filter(Remote.is_public).\
                     join(Component).join(Guid).filter(Guid.value == value).\
                     order_by(Firmware.timestamp.desc()).all()
 
     # new, AppStream ID view
     return db.session.query(Firmware).\
+                    join(Remote).filter(Remote.is_public).\
                     join(Component).filter(Component.appstream_id == value).\
                     order_by(Firmware.timestamp.desc()).all()
 
@@ -73,6 +75,7 @@ def device_show(appstream_id):
         if fw_old:
             fw_previous[fw_old] = fw
         fw_old = fw
+
     return render_template('device.html',
                            appstream_id=appstream_id,
                            fws=fws,

--- a/app/views_shard.py
+++ b/app/views_shard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+
+from flask import request, url_for, redirect, flash, g, render_template
+from flask_login import login_required
+
+from app import app, db
+
+from .models import ComponentShardInfo
+from .util import _error_permission_denied
+
+@app.route('/lvfs/shard/all')
+@login_required
+def shard_all():
+
+    # security check
+    if not g.user.check_acl('@view-shards'):
+        return _error_permission_denied('Unable to view shards')
+
+    # only show shards with the correct group_id
+    shards = db.session.query(ComponentShardInfo).order_by(ComponentShardInfo.cnt.desc()).all()
+    return render_template('shard-list.html',
+                           category='admin',
+                           shards=shards)
+
+@app.route('/lvfs/shard/<int:component_shard_info_id>/modify', methods=['POST'])
+@login_required
+def shard_modify(component_shard_info_id):
+
+    # find shard
+    shard = db.session.query(ComponentShardInfo).\
+                filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id).first()
+    if not shard:
+        flash('No shard found', 'info')
+        return redirect(url_for('.shard_all'))
+
+    # security check
+    if not shard.check_acl('@modify'):
+        return _error_permission_denied('Unable to modify shard')
+
+    # modify shard
+    for key in ['name', 'description']:
+        if key in request.form:
+            setattr(shard, key, request.form[key])
+    db.session.commit()
+
+    # success
+    flash('Modified shard', 'info')
+    return shard_details(component_shard_info_id)
+
+@app.route('/lvfs/shard/<int:component_shard_info_id>/details')
+@login_required
+def shard_details(component_shard_info_id):
+
+    # find shard
+    shard = db.session.query(ComponentShardInfo).\
+            filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id).first()
+    if not shard:
+        flash('No shard found', 'info')
+        return redirect(url_for('.shard_all'))
+
+    # security check
+    if not shard.check_acl('@view'):
+        return _error_permission_denied('Unable to view shard details')
+
+    # show details
+    return render_template('shard-details.html',
+                           category='admin',
+                           shard=shard)

--- a/cron.py
+++ b/cron.py
@@ -28,7 +28,6 @@ from app.models import AnalyticFirmware, Useragent, UseragentKind, Analytic, Rep
 from app.models import _get_datestr_from_datetime
 from app.metadata import _metadata_update_targets, _metadata_update_pulp
 from app.util import _archive_get_files_from_glob, _get_dirname_safe, _event_log
-from app.pluginloader import PluginError
 
 # make compatible with Flask
 app = application.app
@@ -219,7 +218,7 @@ def _check_firmware():
             test.ended_ts = datetime.datetime.utcnow()
             # don't leave a failed task running
             db.session.commit()
-        except PluginError as e:
+        except Exception as e: # pylint: disable=broad-except
             test.ended_ts = datetime.datetime.utcnow()
             test.add_fail('An exception occurred', str(e))
 

--- a/lvfs_test.py
+++ b/lvfs_test.py
@@ -246,13 +246,6 @@ class LvfsTestCase(unittest.TestCase):
         rv = self.app.get('/lvfs/component/1')
         assert b'2082b5e0-7a64-478a-b1b2-e3404fab6dad' in rv.data, rv.data
 
-        # check devices page shows private firmware as admin -- and hidden when anon
-        rv = self.app.get('/lvfs/device')
-        assert b'com.hughski.ColorHug2.firmware' in rv.data, rv.data
-        rv = self.app.get('/lvfs/device/com.hughski.ColorHug2.firmware')
-        assert b'MCDC04 errata' in rv.data, rv.data
-        self.logout()
-
         # check private firmware isn't visible when not logged in
         rv = self.app.get('/lvfs/device')
         assert b'2082b5e0-7a64-478a-b1b2-e3404fab6dad' not in rv.data, rv.data
@@ -277,6 +270,8 @@ class LvfsTestCase(unittest.TestCase):
         self.logout()
         rv = self.app.get('/lvfs/devicelist')
         assert b'ColorHug' in rv.data, rv.data
+        rv = self.app.get('/lvfs/device/com.hughski.ColorHug2.firmware')
+        assert b'MCDC04 errata' in rv.data, rv.data
         self.login()
 
         # download it

--- a/migrations/versions/61b9b75cb259_add_component_shards.py
+++ b/migrations/versions/61b9b75cb259_add_component_shards.py
@@ -1,0 +1,54 @@
+"""
+
+Revision ID: 61b9b75cb259
+Revises: 9997d57e00c4
+Create Date: 2019-05-13 09:51:33.419700
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '61b9b75cb259'
+down_revision = '9997d57e00c4'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.create_table('component_shard_infos',
+    sa.Column('component_shard_info_id', sa.Integer(), nullable=False),
+    sa.Column('guid', sa.String(length=36), nullable=True),
+    sa.Column('name', sa.Text(), nullable=True),
+    sa.Column('description', sa.Text(), nullable=True),
+    sa.Column('cnt', sa.Integer()),
+    sa.PrimaryKeyConstraint('component_shard_info_id'),
+    sa.UniqueConstraint('component_shard_info_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_index(op.f('ix_component_shard_infos_guid'), 'component_shard_infos', ['guid'], unique=False)
+    op.create_table('component_shards',
+    sa.Column('component_shard_id', sa.Integer(), nullable=False),
+    sa.Column('component_id', sa.Integer(), nullable=False),
+    sa.Column('component_shard_info_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['component_id'], ['components.component_id'], ),
+    sa.ForeignKeyConstraint(['component_shard_info_id'], ['component_shard_infos.component_shard_info_id'], ),
+    sa.PrimaryKeyConstraint('component_shard_id'),
+    sa.UniqueConstraint('component_shard_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_table('component_shard_checksums',
+    sa.Column('checksum_id', sa.Integer(), nullable=False),
+    sa.Column('component_shard_id', sa.Integer(), nullable=False),
+    sa.Column('kind', sa.Text(), nullable=False),
+    sa.Column('value', sa.Text(), nullable=False),
+    sa.ForeignKeyConstraint(['component_shard_id'], ['component_shards.component_shard_id'], ),
+    sa.PrimaryKeyConstraint('checksum_id'),
+    sa.UniqueConstraint('checksum_id'),
+    mysql_character_set='utf8mb4'
+    )
+
+def downgrade():
+    op.drop_table('component_shard_checksums')
+    op.drop_table('component_shards')
+    op.drop_index(op.f('ix_component_shard_infos_guid'), table_name='component_shard_infos')
+    op.drop_table('component_shard_infos')

--- a/plugins/chipsec/__init__.py
+++ b/plugins/chipsec/__init__.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+# Licensed under the GNU General Public License Version 2
+#
+# pylint: disable=no-self-use
+
+import tempfile
+import glob
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+
+from app import db
+from app.pluginloader import PluginBase, PluginError, PluginSettingBool, PluginSettingText
+from app.models import Test, ComponentShard, ComponentShardChecksum, ComponentShardInfo
+
+def _add_component_shards(md, files):
+
+    # remove any old shards
+    for shard in md.shards:
+        db.session.delete(shard)
+
+    # parse each EFI binary as a shard
+    for fn in files:
+        sections = fn.rsplit('/')
+        name = sections[-1].split('.')[0]
+        guid = None
+        for section in reversed(sections[:-1]):
+            if section.find('GUID_DEFINED') != -1:
+                continue
+            if section.find('COMPRESSION') != -1:
+                continue
+            guid = section.split('_')[1].split('.')[0].lower()
+            break
+        if not guid:
+            continue
+
+        shard = ComponentShard(component_id=md.component_id)
+        shard.info = db.session.query(ComponentShardInfo).\
+                            filter(ComponentShardInfo.guid == guid).first()
+        if shard.info:
+            shard.info.cnt += 1
+        else:
+            shard.info = ComponentShardInfo(guid, name)
+        with open(fn, 'rb') as f:
+            data = f.read()
+
+            # SHA1 is what's used by researchers, but considered broken
+            csum = ComponentShardChecksum(hashlib.sha1(data).hexdigest(), 'SHA1')
+            shard.checksums.append(csum)
+
+            # SHA256 is now the best we have
+            csum = ComponentShardChecksum(hashlib.sha256(data).hexdigest(), 'SHA256')
+            shard.checksums.append(csum)
+
+        # add shard to component
+        md.shards.append(shard)
+
+def _run_chipsec_on_blob(self, test, md):
+
+    # write firmware to temp file
+    cwd = tempfile.mkdtemp(prefix='lvfs')
+    src = tempfile.NamedTemporaryFile(mode='wb',
+                                      prefix='lvfs_',
+                                      suffix=".bin",
+                                      dir=cwd,
+                                      delete=False)
+    src.write(md.blob)
+    src.flush()
+
+    # log file output
+    log = tempfile.NamedTemporaryFile(mode='wb',
+                                      prefix='lvfs_',
+                                      suffix=".log",
+                                      dir=cwd,
+                                      delete=False)
+
+    # run chipsec
+    cmd = self.get_setting('chipsec_binary', required=True)
+    argv = [cmd, '--no_driver', '--log', log.name, 'uefi', 'decode', src.name]
+    ps = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
+    if ps.wait() != 0:
+        raise PluginError('Failed to decode file: %s' % ps.stderr.read())
+
+    # look for shards
+    outdir = src.name + '.dir'
+    files = glob.glob(outdir + '/FV/**/*.efi', recursive=True)
+    if not files:
+        test.add_pass('Parsed, but no firmware volumes found')
+        return
+    _add_component_shards(md, files)
+
+    # print output
+    with open(log.name, 'r') as f:
+        test.add_pass('Parsed and extracted', f.read())
+
+    # delete output dir
+    shutil.rmtree(cwd)
+
+class Plugin(PluginBase):
+    def __init__(self):
+        PluginBase.__init__(self)
+
+    def name(self):
+        return 'CHIPSEC'
+
+    def summary(self):
+        return 'Add firmware shards for UEFI capsules'
+
+    def settings(self):
+        s = []
+        s.append(PluginSettingBool('chipsec_enabled', 'Enabled', True))
+        s.append(PluginSettingText('chipsec_binary', 'CHIPSEC executable', 'chipsec_util'))
+        return s
+
+    def ensure_test_for_fw(self, fw):
+
+        # only run for capsule updates
+        require_test = False
+        for md in fw.mds:
+            if not md.protocol:
+                continue
+            if md.protocol.value == 'org.uefi.capsule':
+                require_test = True
+
+        # add if not already exists
+        if require_test:
+            test = fw.find_test_by_plugin_id(self.id)
+            if not test:
+                test = Test(self.id, waivable=True)
+                fw.tests.append(test)
+
+    def run_test_on_fw(self, test, fw):
+
+        # run chipsec on the capsule data
+        for md in fw.mds:
+            if md.protocol.value != 'org.uefi.capsule':
+                continue
+            if not md.blob:
+                continue
+            _run_chipsec_on_blob(self, test, md)
+        db.session.commit()

--- a/plugins/dfu/__init__.py
+++ b/plugins/dfu/__init__.py
@@ -4,19 +4,12 @@
 # Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
 # Licensed under the GNU General Public License Version 2
 #
-# pylint: disable=no-self-use,wrong-import-position
+# pylint: disable=no-self-use
 
 import struct
 import zlib
 
-import gi
-gi.require_version('GCab', '1.0')
-from gi.repository import GCab
-from gi.repository import Gio
-from gi.repository import GLib
-
 from app.pluginloader import PluginBase, PluginError, PluginSettingBool
-from app.util import _archive_get_files_from_glob, _get_absolute_path
 from app.models import Test
 
 class Plugin(PluginBase):
@@ -53,39 +46,24 @@ class Plugin(PluginBase):
 
     def run_test_on_fw(self, test, fw):
 
-        # decompress firmware
-        fn = _get_absolute_path(fw)
-        try:
-            istream = Gio.File.new_for_path(fn).read()
-        except GLib.Error as e: # pylint: disable=catching-non-exception
-            raise PluginError(e)
-        cfarchive = GCab.Cabinet.new()
-        cfarchive.load(istream)
-        cfarchive.extract(None)
-
         # check each file
         for md in fw.mds:
             if md.protocol.value != 'org.usb.dfu':
                 continue
-
-            # get the component contents data
-            cfs = _archive_get_files_from_glob(cfarchive, md.filename_contents)
-            if not cfs or len(cfs) > 1:
-                test.add_fail('Open', '%s not found in archive' % md.filename_contents)
+            if not md.blob:
                 continue
-            contents = cfs[0].get_bytes().get_data()
 
             # unpack the footer
-            sz = len(contents)
+            sz = len(md.blob)
             if sz < 16:
                 test.add_fail('FileSize', '0x%x' % sz)
                 # we have to abort here, no further tests are possible
                 continue
 
-            footer = contents[sz - 16:]
+            footer = md.blob[sz - 16:]
             try:
                 data = struct.unpack('<HHHH3sBL', footer)
-            except struct.error as e:
+            except struct.error as _:
                 test.add_fail('Footer', footer)
                 # we have to abort here, no further tests are possible
                 continue
@@ -121,7 +99,7 @@ class Plugin(PluginBase):
                 test.add_fail('DFU Length', '0x%02x is not valid' % data[5])
 
             # check dwCRC
-            crc_correct = zlib.crc32(contents[:sz-4]) ^ 0xffffffff
+            crc_correct = zlib.crc32(md.blob[:sz-4]) ^ 0xffffffff
             if data[6] == crc_correct:
                 test.add_pass('CRC', '0x%04x' % data[6])
             else:


### PR DESCRIPTION
This allows us to show what modules make up each firmware volume, and in the
future means we can do attestation and verification of the installed modules.

At the moment it's really useful to see what modules are shared between models
and vendors, and would allow us to construct a blocklist in the future for
known broken firmware.