### PR TITLE
Show per-plugin test results in the admin view

### DIFF
--- a/app/templates/private.html
+++ b/app/templates/private.html
@@ -155,7 +155,7 @@
           </a>
           <ul class="nav collapse {{'show' if category == 'settings'}}" id="settings" data-parent="#navbarVerticalCollapse">
 {% for plugin in loader_plugins %}
-            <li class="nav-item {{'active' if request.url_rule.endpoint == 'settings_view' and plugin_id == plugin.id}}">
+            <li class="nav-item {{'active' if category == 'settings' and plugin_id == plugin.id}}">
               <a class="nav-link" href="{{url_for('.settings_view', plugin_id=plugin.id)}}">{{plugin.name()}}</a>
             </li>
 {% endfor %}

--- a/app/templates/settings-nav.html
+++ b/app/templates/settings-nav.html
@@ -1,0 +1,34 @@
+{% if tests_by_type %}
+<nav class="row">
+  <div class="col col-sm-10 text-center mb-3">
+    <div class="btn-group" role="group">
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_view' else 'default'}}"
+        href="{{url_for('.settings_view', plugin_id=plugin.id)}}">Settings</a>
+{% if tests_by_type['recent'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='recent' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='recent', plugin_id=plugin.id)}}">Recent Tests</a>
+{% endif %}
+{% if tests_by_type['pending'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='pending' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='pending', plugin_id=plugin.id)}}">Pending Tests ({{tests_by_type['pending']|length}})</a>
+{% endif %}
+{% if tests_by_type['running'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='running' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='running', plugin_id=plugin.id)}}">Running Tests ({{tests_by_type['running']|length}})</a>
+{% endif %}
+{% if tests_by_type['success'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='success' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='success', plugin_id=plugin.id)}}">Success Tests ({{tests_by_type['success']|length}})</a>
+{% endif %}
+{% if tests_by_type['failed'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='failed' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='failed', plugin_id=plugin.id)}}">Failed Tests ({{tests_by_type['failed']|length}})</a>
+{% endif %}
+{% if tests_by_type['waived'] %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'settings_tests' and kind=='waived' else 'default'}}"
+        href="{{url_for('.settings_tests', kind='waived', plugin_id=plugin.id)}}">Waived Tests ({{tests_by_type['waived']|length}})</a>
+{% endif %}
+    </div>
+  </div>
+</nav>
+{% endif %}

--- a/app/templates/settings-tests.html
+++ b/app/templates/settings-tests.html
@@ -1,0 +1,65 @@
+{% extends "default.html" %}
+{% block title %}Runtime Tests{% endblock %}
+
+{% block nav %}{% include 'settings-nav.html' %}{% endblock %}
+
+{% block content %}
+{% if tests|length == 0 %}
+<div class="card">
+  <div class="card-body">
+    <div class="card-title">Tests</div>
+    <p class="card-text">
+      No tests in this state.
+    </p>
+  </div>
+</div>
+{% endif %}
+
+{% for test in tests %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-{{test.color}}">
+    {{test.fw.md_prio.developer_name}} {{test.fw.md_prio.name}} v{{test.fw.md_prio.version_display}}
+    <span class="float-right">{{test.timestamp}}</span>
+  </div>
+  <div class="card-body">
+{% if test.is_pending %}
+    <p class="card-text">Test is pending…</p>
+{% elif test.is_running %}
+    <p class="card-text">Test is running since {{test.started_ts}}…</p>
+{% endif %}
+{% if test.attributes|length > 0 %}
+    <ul class="card-text">
+{% for attr in test.attributes %}
+      <li class="list-group-item">
+{% if attr.message %}
+        <code>{{attr.title}}: {{attr.message}}</code>
+{% else %}
+        <code>{{attr.title}}</code>
+{% endif %}
+      </li>
+{% endfor %}
+    </ul>
+{% endif %}
+      <a class="card-link btn btn-info"
+         href="{{url_for('.firmware_show', firmware_id=test.firmware_id)}}"
+         role="button">Details</a>
+{% if test.started_ts and test.check_acl('@retry') %}
+      <a class="card-link btn btn-info"
+         href="{{url_for('.test_retry', test_id=test.test_id)}}"
+         role="button">Retry</a>
+{% endif %}
+{% if not test.success and test.ended_ts and test.waivable and not test.waived_ts and test.check_acl('@waive') %}
+      <a class="card-link btn btn-warning"
+         href="{{url_for('.test_waive', test_id=test.test_id)}}"
+         role="button">Waive</a>
+{% endif %}
+  </div>
+{% if test.waived_ts %}
+  <div class="card-footer">
+    Waived by <code>{{test.waived_user.username}}</code>
+  </div>
+{% endif %}
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,13 +1,12 @@
 {% extends "default.html" %}
 {% block title %}Settings{% endblock %}
 
+{% block nav %}{% include 'settings-nav.html' %}{% endblock %}
+
 {% block content %}
 <div class="card">
   <div class="card-body">
-  <form class="form" method="post" action="{{url_for('.settings_modify', plugin_id=plugin_id)}}">
-
-{% for plugin in loader_plugins %}
-{% if plugin.id == plugin_id %}
+  <form class="form" method="post" action="{{url_for('.settings_modify', plugin_id=plugin.id)}}">
     <div class="card-title">{{plugin.name()}}</div>
     <p class="card-text">{{plugin.summary()}}</p>
 {% for s in plugin.settings() %}
@@ -32,8 +31,6 @@
       <input type="text" class="form-control" name="{{s.key}}" value="{{settings[s.key]}}">
 {% endif %}
     </div>
-{% endfor %}
-{% endif %}
 {% endfor %}
     <input type="submit" class="card-link btn btn-primary" value="Modify">
   </form>


### PR DESCRIPTION
This is more useful when tracking down specific test failures, and with the
growth of the LVFS is more scalable than just showing everything for all tests.