### PR TITLE
templates: Fix typos "theshold" -> "threshold"

### DIFF
--- a/lvfs/pluginloader.py
+++ b/lvfs/pluginloader.py
@@ -110,7 +110,7 @@ class PluginGeneral(PluginBase):
                                    'https://fwupd.org/downloads/'))
         s.append(PluginSettingTextList('hwinfo_kinds', 'Allowed hwinfo Types', ['nvme']))
         s.append(PluginSettingInteger('default_failure_minimum', 'Report failures required to demote', 5))
-        s.append(PluginSettingInteger('default_failure_percentage', 'Report failures theshold for demotion', 70))
+        s.append(PluginSettingInteger('default_failure_percentage', 'Report failures threshold for demotion', 70))
         return s
 
 class Pluginloader:

--- a/lvfs/templates/firmware-limits.html
+++ b/lvfs/templates/firmware-limits.html
@@ -24,7 +24,7 @@
       <input type="number" min="1" max="100" class="form-control" name="failure_minimum" value="{{fw.failure_minimum}}">
     </div>
     <div class="form-group">
-      <label>Theshold Percentage</label>
+      <label>Threshold Percentage</label>
       <input type="number" min="1" max="100" class="form-control" name="failure_percentage" value="{{fw.failure_percentage}}">
     </div>
     <input type="submit" class="btn btn-primary card-link" value="Change"/>


### PR DESCRIPTION
## In short
* Fix minor typos of `theshold` → `threshold`
  * No functional changes, but may affect translations

*As this is a very small change, I've skipped the usual breakdown and risk analysis*