### PR TITLE
Show the user capabilities in the headerbar

### DIFF
--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -337,6 +337,25 @@
         </ul>
         <ul class="navbar-nav align-items-center ml-auto">
           <li class="nav-item dropdown"><a class="nav-link pr-0" id="navbarDropdownUser" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+{% if g.user.is_admin and 1 %}
+            <span class="badge badge-danger text-uppercase">Admin</span>
+{% endif %}
+{% if g.user.is_qa and 1 %}
+            <span class="badge badge-warning text-uppercase">QA</span>
+{% else %}
+            <span class="badge badge-info text-uppercase">Limited</span>
+{% endif %}
+{% if g.user.is_analyst and 1 %}
+            <span class="badge badge-info text-uppercase">Analyst</span>
+{% endif %}
+{% if g.user.vendor_manager %}
+            <span class="badge badge-info text-uppercase">Manager</span>
+{% endif %}
+{% if g.user.is_approved_public and 1 %}
+            <span class="badge badge-success text-uppercase">Trusted</span>
+{% else %}
+            <span class="badge badge-info text-uppercase">Untrusted</span>
+{% endif %}
               <div class="avatar avatar-xl">
                 <span class="fas fa-user fa-2x"></span>
               </div>


### PR DESCRIPTION
I got asked today how users are supposed to know what user level they are.

I think it's better to show in the header next to the 'person' rather than in
the profile view, the latter being where things get changed.