### PR TITLE
Allow firmware or vendors to enable DoNotTrack functionality

### DIFF
--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -383,6 +383,7 @@ class Vendor(db.Model):
     version_format = Column(String(10), default=None) # usually 'triplet' or 'quad'
     url = Column(Text, default=None)
     banned_country_codes = Column(Text, default=None) # ISO 3166, delimiter ','
+    do_not_track = Column(Boolean, default=False)
 
     # magically get the users in this vendor group
     users = relationship("User",
@@ -1571,6 +1572,7 @@ class Firmware(db.Model):
     report_issue_cnt = Column(Integer, default=0)       # updated by cron.py
     failure_minimum = Column(Integer, default=0)
     failure_percentage = Column(Integer, default=0)
+    _do_not_track = Column('do_not_track', Boolean, default=False)
 
     # include all Component objects
     mds = relationship("Component",
@@ -1607,6 +1609,10 @@ class Firmware(db.Model):
         if not self.events:
             return 0
         return datetime.datetime.utcnow() - self.events[-1].timestamp
+
+    @property
+    def do_not_track(self):
+        return self._do_not_track or self.vendor.do_not_track
 
     @property
     def is_deleted(self):

--- a/lvfs/templates/dashboard.html
+++ b/lvfs/templates/dashboard.html
@@ -24,7 +24,7 @@
 </div>
 {% endif %}
 
-{% if download_cnt > 0 %}
+{% if not g.user.vendor.do_not_track and download_cnt > 0 %}
 <div class="card">
   <div class="card-body rounded-soft bg-gradient">
     <h5 class="text-white">Downloads over the last 30 days</h5>
@@ -88,7 +88,19 @@ new Chart(ctx, {
 {% endif %}
 
 <div class="card-deck mt-3">
-{% if g.user.vendor.fws|length %}
+{% if g.user.vendor.do_not_track %}
+  <div class="card overflow-hidden" style="min-width: 12rem">
+    <div class="bg-holder bg-card" style="background-image:url(/img/corner-1.png);"></div>
+    <div class="card-body position-relative">
+      <div class="card-title">Do Not Track in use</div>
+      <p class="card-text">
+        No download counts, telemetry or user reports are available for any
+        firmware.
+        Please consult your manager for more information.
+      </p>
+    </div>
+  </div>
+{% elif not g.user.vendor.do_not_track and g.user.vendor.fws|length %}
   <div class="card overflow-hidden" style="min-width: 12rem">
     <div class="bg-holder bg-card" style="background-image:url(/img/corner-1.png);"></div>
     <div class="card-body position-relative">

--- a/lvfs/templates/firmware-details.html
+++ b/lvfs/templates/firmware-details.html
@@ -86,11 +86,14 @@ new Chart(ctx, {
           <img class="img-thumbnail float-right" src="/uploads/{{fw.vendor.icon}}" width="64"/>
         </div>
         <p class="card-text">
-          <a href="{{fw.filename_absolute}}">
-          {{fw.md_prio.name}} {{fw.version_display}}
-          </a>
+{% if fw.do_not_track %}
+          No download statistics are available for this firmware as
+          <code>LVFS::DoNotTrack</code> is being used.
+{% else %}
+          <a href="{{fw.filename_absolute}}">{{fw.md_prio.name}} {{fw.version_display}}</a>
           has been downloaded {{fw.download_cnt}} times.
         </p>
+{% endif %}
 {% if fw.signed_timestamp %}
 <!-- Signed: {{fw.signed_timestamp}} -->
 {% endif %}

--- a/lvfs/templates/firmware-nav.html
+++ b/lvfs/templates/firmware-nav.html
@@ -21,7 +21,7 @@
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'firmware_problems' else 'default'}}"
         href="{{url_for('.firmware_problems', firmware_id=fw.firmware_id)}}">Problems</a>
 {% endif %}
-{% if fw.check_acl('@add-limit') or fw.check_acl('@remove-limit') %}
+{% if not fw.do_not_track and (fw.check_acl('@add-limit') or fw.check_acl('@remove-limit')) %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'firmware_limits' else 'default'}}"
         href="{{url_for('.firmware_limits', firmware_id=fw.firmware_id)}}">Limits</a>
 {% endif %}

--- a/lvfs/templates/firmware-search.html
+++ b/lvfs/templates/firmware-search.html
@@ -47,10 +47,12 @@
 {% endif %}
     </td>
     <td class="col col-sm-1">
+{% if not fw.do_not_track %}
       <span class="text-muted">
         <img src="/img/symbolic-download.svg" width="24" alt="download icon"/>
         {{format_humanize_intchar(fw.download_cnt)}}
       </span>
+{% endif %}
     </td>
     <td class="col col-sm-2">
       <a class="btn btn-info btn-block"

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -90,7 +90,7 @@
             </li>
           </ul>
         </li>
-{% if g.user.check_acl('@view-analytics') %}
+{% if not g.user.vendor.do_not_track and g.user.check_acl('@view-analytics') %}
         <li class="nav-item">
           <a class="nav-link dropdown-indicator" href="#telemetry" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="telemetry">
             <div class="d-flex align-items-center">

--- a/lvfs/templates/upload.html
+++ b/lvfs/templates/upload.html
@@ -31,6 +31,13 @@
     <p class="card-text">
       Uploading firmware is covered by <a href="{{url_for('.agreement_show')}}">our legal agreement</a>.
     </p>
+{% if g.user.vendor.do_not_track %}
+    <div class="alert alert-info mb-3" role="alert">
+      Your vendor manager has globally enabled &lsquo;Do Not Track&rsquo; for all firmware.
+      No download statistics or user reports will be available for any files
+      uploaded by your user account.
+    </div>
+{% endif %}
     <form action="{{url_for('.upload_firmware')}}" method="post" enctype="multipart/form-data" class="form">
       <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
 {% if affiliations|length %}

--- a/lvfs/templates/vendor-details.html
+++ b/lvfs/templates/vendor-details.html
@@ -105,6 +105,13 @@
     </select>
   </div>
   <div class="form-group">
+    <label for="email">Enable &lsquo;Do Not Track&rsquo;</label>
+    <select class="form-control" name="do_not_track">
+      <option value="0" {{ 'selected' if v.do_not_track == 0 }}>No</option>
+      <option value="1" {{ 'selected' if v.do_not_track == 1 }}>Yes</option>
+    </select>
+  </div>
+  <div class="form-group">
     <label for="email">Comments:</label>
     <textarea class="form-control" name="comments" cols="64" rows="5">{{v.comments}}</textarea>
   </div>

--- a/lvfs/uploadedfile.py
+++ b/lvfs/uploadedfile.py
@@ -449,6 +449,10 @@ class UploadedFile:
         if component.xpath('custom/value[@key="LVFS::InhibitDownload"]'):
             md.inhibit_download = True
 
+        # allows OEM to disable ignore all kinds of statistics on this firmware
+        if component.xpath('custom/value[@key="LVFS::DoNotTrack"]'):
+            md.fw.do_not_track = True
+
         # allows OEM to change the triplet (AA.BB.CCDD) to quad (AA.BB.CC.DD)
         try:
             md.version_format = _node_validate_text(component.xpath('custom/value[@key="LVFS::VersionFormat"]')[0])

--- a/lvfs/views.py
+++ b/lvfs/views.py
@@ -121,13 +121,15 @@ def serveStaticResource(resource):
                     return resp
 
         # this is cached for easy access on the firmware details page
-        fw.download_cnt += 1
+        if not fw.do_not_track:
+            fw.download_cnt += 1
 
         # log the client request
-        db.session.add(Client(addr=_addr_hash(_get_client_address()),
-                              firmware_id=fw.firmware_id,
-                              user_agent=user_agent))
-        db.session.commit()
+        if not fw.do_not_track:
+            db.session.add(Client(addr=_addr_hash(_get_client_address()),
+                                  firmware_id=fw.firmware_id,
+                                  user_agent=user_agent))
+            db.session.commit()
 
     # firmware blobs
     if resource.startswith('downloads/'):

--- a/lvfs/views_firmware.py
+++ b/lvfs/views_firmware.py
@@ -519,7 +519,7 @@ def firmware_show(firmware_id):
     # get data for the last month or year
     graph_data = []
     graph_labels = None
-    if fw.check_acl('@view-analytics'):
+    if fw.check_acl('@view-analytics') and not fw.do_not_track:
         if fw.timestamp > datetime.datetime.today() - datetime.timedelta(days=30):
             datestr = _get_datestr_from_datetime(datetime.date.today() - datetime.timedelta(days=31))
             data = db.session.query(AnalyticFirmware.cnt).\

--- a/lvfs/views_report.py
+++ b/lvfs/views_report.py
@@ -167,6 +167,11 @@ def firmware_report():
             msgs.append('%s did not match any known firmware archive' % report['Checksum'])
             continue
 
+        # cannot report this failure
+        if fw.do_not_track:
+            msgs.append('%s will not accept reports' % report['Checksum'])
+            continue
+
         # update the device checksums if there is only one component
         if crt and crt.user.is_qa and 'ChecksumDevice' in data and len(fw.mds) == 1:
             md = fw.md_prio

--- a/lvfs/views_vendor.py
+++ b/lvfs/views_vendor.py
@@ -359,6 +359,7 @@ def vendor_modify_by_admin(vendor_id):
         if key in request.form:
             setattr(vendor, key, request.form[key])
     for key in ['is_embargo_default',
+                'do_not_track',
                 'visible',
                 'visible_on_landing',
                 'visible_for_search']:

--- a/migrations/versions/38831f5bfa01_add_do_not_track.py
+++ b/migrations/versions/38831f5bfa01_add_do_not_track.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 38831f5bfa01
+Revises: 3c0998391bb4
+Create Date: 2019-08-04 14:34:28.624079
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '38831f5bfa01'
+down_revision = '3c0998391bb4'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('firmware', sa.Column('do_not_track', sa.Boolean(), nullable=True))
+    op.add_column('vendors', sa.Column('do_not_track', sa.Boolean(), nullable=True))
+
+def downgrade():
+    op.drop_column('vendors', 'do_not_track')
+    op.drop_column('firmware', 'do_not_track')


### PR DESCRIPTION
This allows either entire vendors to globally opt out of the download and
success reporting, or restrict it from specific firmware objects. Enabling the
LVFS::DoNotTrack feature disables a lot of the useful vendor functionality
(including the per-firmware limits and auto-demotion functionality) and is not
recommended by the LVFS admins.