### PR TITLE
Split up the vendor display name

### DIFF
--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -363,6 +363,7 @@ class Vendor(db.Model):
     vendor_id = Column(Integer, primary_key=True, unique=True)
     group_id = Column(String(80), nullable=False, index=True)
     display_name = Column(Text, default=None)
+    internal_team = Column(Text, default=None)
     plugins = Column(Text, default=None)
     description = Column(Text, default=None)
     quote_text = Column(Text, default=None)
@@ -445,6 +446,12 @@ class Vendor(db.Model):
     @property
     def is_account_holder(self):
         return self.users
+
+    @property
+    def display_name_with_team(self):
+        if self.internal_team:
+            return '{} ({})'.format(self.display_name, self.internal_team)
+        return self.display_name
 
     @property
     def ctime(self):

--- a/lvfs/templates/metadata.html
+++ b/lvfs/templates/metadata.html
@@ -69,7 +69,7 @@
 <div class="card mt-3">
   <div class="card-body">
     <div class="card-title">
-      {{v.display_name}} Embargo
+      {{v.display_name_with_team}} Embargo
       <span class="badge badge-warning">Private</span>
       <a class="float-right" href="/downloads/{{v.remote.filename}}">
         <code>{{v.remote.filename[:16]}}</code>

--- a/lvfs/templates/upload.html
+++ b/lvfs/templates/upload.html
@@ -44,7 +44,7 @@
       <div class="form-group card-text">
         <label for="vendor_id">Upload for vendor</label>
         <select class="form-control pt-0 pb-0 pl-0 pr-0" name="vendor_id" size="{{affiliations|length+1}}" required>
-          <option class="pt-2 pb-2 pl-2" value="{{g.user.vendor.vendor_id}}">{{g.user.vendor.display_name}}</option>
+          <option class="pt-2 pb-2 pl-2" value="{{g.user.vendor.vendor_id}}">{{g.user.vendor.display_name_with_team}}</option>
 {% for r in affiliations %}
           <option class="pt-2 pb-2 pl-2" value="{{r.vendor.vendor_id}}">{{r.vendor.display_name}}</option>
 {% endfor %}

--- a/lvfs/templates/vendor-details.html
+++ b/lvfs/templates/vendor-details.html
@@ -24,6 +24,10 @@
     <input type="text" class="form-control" name="display_name" value="{{v.display_name}}" required>
   </div>
   <div class="form-group">
+    <label for="internal_team">Internal Team:</label>
+    <input type="text" class="form-control" name="internal_team" value="{{v.internal_team if v.internal_team}}">
+  </div>
+  <div class="form-group">
     <label for="url">Vendor URL:</label>
     <input type="text" class="form-control" name="url" value="{{v.url if v.url}}">
   </div>

--- a/lvfs/templates/vendorlist.html
+++ b/lvfs/templates/vendorlist.html
@@ -25,12 +25,12 @@
     <td class="col col-sm-3">
 {% if v.visible %}
 {% if v.url %}
-      <a href="{{v.url}}">{{v.display_name}}</a>
+      <a href="{{v.url}}">{{v.display_name_with_team}}</a>
 {% else %}
       {{v.display_name}}
 {% endif %}
 {% else %}
-      <em>{{v.display_name}} [private]</em>
+      <em>{{v.display_name_with_team}} [private]</em>
 {% endif %}
 {% if v.icon %}
       <img class="img-thumbnail float-right" src="/uploads/{{v.icon}}" width="96"/>

--- a/lvfs/views_vendor.py
+++ b/lvfs/views_vendor.py
@@ -343,6 +343,7 @@ def vendor_modify_by_admin(vendor_id):
         flash('Failed to modify vendor: No a vendor with that group ID', 'warning')
         return redirect(url_for('.vendor_list'), 302)
     for key in ['display_name',
+                'internal_team',
                 'plugins',
                 'quote_text',
                 'quote_author',


### PR DESCRIPTION
Some OEMs have more than one vendor group on the LVFS. In this case the team
should be displayed in a different way to the OEM name, for instance we never
want to show 'Lenovo ThinkPad ThinkPad P50' when displaying firmware.

We can't migrate this automatically, as quite a few vendors are testing the
LVFS in secret and wouldn't want the internal team names exposed in the
migration scripts.